### PR TITLE
revised layout with map alongside content

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -19,6 +19,15 @@ h6,
   margin-bottom: 0.5em;
 }
 
+.district-header {
+  .boro {
+    display: block;
+    font-weight: $global-weight-normal;
+    font-size: 0.75em;
+    line-height: 1;
+  }
+}
+
 //
 // Typograhpy helper classes
 // --------------------------------------------------

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -2,30 +2,30 @@
 // Layout default
 // --------------------------------------------------
 
+//
+// Basic page layout
+// --------------------------------------------------
+
+// #main wraps everything except the header
 #main {
   @include breakpoint(large) {
     height: calc(100vh - 97px);
   }
 }
 
-#page-content {
-  @include breakpoint(large) {
-    overflow: auto
-  }
-}
-
-.leaflet-container {
-  height: calc(50vh);
-  width: 100%;
-  z-index: 1;
-
-  @include breakpoint(large) {
-    height: 100%;
-  }
-}
-
+// #cd-chooser contains the map and search
 #cd-chooser {
   position: relative;
+
+  .leaflet-container {
+    height: calc(50vh);
+    width: 100%;
+    z-index: 1;
+
+    @include breakpoint(large) {
+      height: 100%;
+    }
+  }
 }
 
 #cd-search {
@@ -43,10 +43,9 @@
   }
 }
 
-#general-statistics {
-  padding: 1em;
-}
-
-.ui.selection.dropdown.visible, .ui.selection.dropdown.active {
-  z-index: 9999;
+// #page-content is everything in main not in #cd-chooser
+#page-content {
+  @include breakpoint(large) {
+    overflow: auto
+  }
 }

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -3,13 +3,14 @@
 // --------------------------------------------------
 
 #main {
+  @include breakpoint(large) {
+    height: calc(100vh - 97px);
+  }
 }
 
-.section-padded {
-  padding: $global-margin 0;
-
+#page-content {
   @include breakpoint(large) {
-    padding: $global-margin*2 0;
+    overflow: auto
   }
 }
 
@@ -17,6 +18,10 @@
   height: calc(50vh);
   width: 100%;
   z-index: 1;
+
+  @include breakpoint(large) {
+    height: 100%;
+  }
 }
 
 #cd-chooser {
@@ -30,6 +35,12 @@
   right: $global-margin;
   bottom: $global-margin*2;
   left: $global-margin;
+
+  @include breakpoint(large) {
+    top: $global-margin;
+    bottom: auto;
+    left: rem-calc(60);
+  }
 }
 
 #general-statistics {
@@ -39,5 +50,3 @@
 .ui.selection.dropdown.visible, .ui.selection.dropdown.active {
   z-index: 9999;
 }
-
-

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -45,7 +45,10 @@
 
 // #page-content is everything in main not in #cd-chooser
 #page-content {
+  padding-top: $global-margin;
+
   @include breakpoint(large) {
+    padding-top: $global-margin/2;
     overflow: auto
   }
 }

--- a/app/styles/modules/_m-labs-beta-notice.scss
+++ b/app/styles/modules/_m-labs-beta-notice.scss
@@ -7,7 +7,7 @@
   color: #fff;
   font-size: 12px;
   font-weight: bold;
-  height: 22px;
+  height: rem-calc(22);
   line-height: 22px;
   text-align: center;
   background-color: #D96B27;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -19,39 +19,30 @@
   </div>
 </header>
 
-<div id="main">
-
-  <div class="grid-x">
-    {{#if mapState.currentlySelected}}
-      <div class="small-6 cell padding" id="general-statistics">
-      </div>
-    {{/if}}
-    <div class="auto cell">
-      <div id="cd-chooser">
-        {{#leaflet-map bounds=mapState.bounds scrollWheelZoom=false onLoad=(action 'handleMapLoad')}}
-          {{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
-          {{#geojson-layer geoJSON=model style=style onClick=(action "handleClick") onMouseover=(action "handleMouseover")}}
-            {{#tooltip-layer}}
-              <p>{{tooltip-text}}</p>
-            {{/tooltip-layer}}
-          {{/geojson-layer}}
-        {{/leaflet-map}}
-        <div id="cd-search">
-          {{#power-select
-            options=options
-            selected=selected
-            searchField="name"
-            placeholder="Enter a Community District or neighborhood..."
-            onchange=(route-action 'transitionToProfile')
-            as |district|
-          }}
-            {{district.boro}} {{district.cd}}
-          {{/power-select}}
-        </div>
-      </div>
+<div id="main" class="grid-x">
+  <div class="cell large-4"  id="cd-chooser">
+    {{#leaflet-map bounds=mapState.bounds scrollWheelZoom=false onLoad=(action 'handleMapLoad')}}
+      {{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
+      {{#geojson-layer geoJSON=model style=style onClick=(action "handleClick") onMouseover=(action "handleMouseover")}}
+        {{#tooltip-layer}}
+          <p>{{tooltip-text}}</p>
+        {{/tooltip-layer}}
+      {{/geojson-layer}}
+    {{/leaflet-map}}
+    <div id="cd-search">
+      {{#power-select
+        options=options
+        selected=selected
+        searchField="name"
+        placeholder="Enter a Community District or neighborhood..."
+        onchange=(route-action 'transitionToProfile')
+        as |district|
+      }}
+        {{district.boro}} {{district.cd}}
+      {{/power-select}}
     </div>
   </div>
-
-{{outlet}}
-
+  <div class="cell large-auto" id="page-content">
+    {{outlet}}
+  </div>
 </div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,7 +1,7 @@
 <div class="grid-container">
 
   <div class="grid-x grid-padding-x">
-    <div class="cell section-padded">
+    <div class="cell">
       <h1>Welcome</h1>
       <p class="lead">This is the welcome message which tells users what the tool is.</p>
     </div>

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -1,17 +1,44 @@
-{{#if mapState.currentlySelected}}
-  {{#ember-wormhole to="general-statistics"}}
-    All about {{model.properties.boro}}:<br/>
-    Crime: 0
-  {{/ember-wormhole}}
-{{/if}}
-
 <div class="grid-container">
   <div class="grid-x grid-padding-x">
-    <div class="cell section-padded">
-      <h1>{{model.boro}} Community District {{model.cd}}</h1>
-      {{land-use-map}}
-      {{log model}}
-      {{outlet}}
+    <div class="cell">
+
+      <h1 class="district-header">
+        <span class="boro">{{model.properties.boro}}</span>
+        Community District {{model.properties.cd}}
+      </h1>
+      <p>
+        All about {{model.properties.boro}}:<br/>
+        Crime: 0
+      </p>
+
+      <section class="callout">
+        <div class="grid-container">
+          <div class="grid-x grid-padding-x">
+            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
+            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
+            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
+            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="callout">
+        <div class="grid-container">
+          <div class="grid-x grid-padding-x">
+            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
+            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
+            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
+            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="callout">
+        {{land-use-map}}
+        {{log model}}
+        {{outlet}}
+      </section>
+
     </div>
   </div>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1451,12 +1451,6 @@
         "hoek": "2.16.3"
       }
     },
-    "bower": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
-      "integrity": "sha1-Vdvr7wrZFVOC2enT5JfBNyNFtEo=",
-      "dev": true
-    },
     "bower-config": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.0.tgz",
@@ -3130,7 +3124,6 @@
       "requires": {
         "amd-name-resolver": "0.0.6",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "bower": "1.8.0",
         "bower-config": "1.4.0",
         "bower-endpoint-parser": "0.2.2",
         "broccoli-babel-transpiler": "6.1.1",


### PR DESCRIPTION
This PR…  
- moves the map to 100% height alongside the content (which scrolls independently)
- puts the ember-power-select at the top of the map on large screens (would get lost in bottom corner in this new layout)
- adds some style for District headers
- stubs in some Callouts (Foundation component) for subsections
