### PR TITLE
sample stats, header shadow

### DIFF
--- a/app/styles/_settings.scss
+++ b/app/styles/_settings.scss
@@ -205,7 +205,7 @@ $subheader-color: inherit;
 $subheader-font-weight: $global-weight-normal;
 $subheader-margin-top: 0.2rem;
 $subheader-margin-bottom: 0.5rem;
-$stat-font-size: 2.5rem;
+$stat-font-size: 4rem;
 
 // 6. Abide
 // --------

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -48,7 +48,7 @@
   padding-top: $global-margin;
 
   @include breakpoint(large) {
-    padding-top: $global-margin/2;
+    padding-top: $global-margin*1.25;
     overflow: auto
   }
 }

--- a/app/styles/modules/_m-site-header.scss
+++ b/app/styles/modules/_m-site-header.scss
@@ -6,6 +6,9 @@ $logo-height-small: rem-calc(24);
 $logo-height-medium: rem-calc(36);
 
 .site-header {
+  position: relative;
+  z-index: 2;
+  box-shadow: 0 4px 0 rgba(0,0,0,0.1);
 
   .branding {
     padding-top: $global-margin;

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -6,28 +6,35 @@
         <span class="boro">{{model.properties.boro}}</span>
         Community District {{model.properties.cd}}
       </h1>
-      <p>
-        All about {{model.properties.boro}}:<br/>
-        Crime: 0
-      </p>
+      <div class="grid-x grid-padding-x medium-up-2 large-up-4">
+        <div class="cell"><p><strong>Statistic:</strong> 42</p></div>
+        <div class="cell"><p><strong>Statistic:</strong> 92</p></div>
+        <div class="cell"><p><strong>Statistic:</strong> 128</p></div>
+        <div class="cell"><p><strong>Statistic:</strong> 8</p></div>
+        <div class="cell"><p><strong>Statistic:</strong> 16</p></div>
+        <div class="cell"><p><strong>Statistic:</strong> 1.3M</p></div>
+        <div class="cell"><p><strong>Statistic:</strong> 7,539</p></div>
+      </div>
 
       <section class="callout">
         <div class="grid-container">
-          <div class="grid-x grid-padding-x">
-            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
-            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
-            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
-            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
-          </div>
-        </div>
-      </section>
-
-      <section class="callout">
-        <div class="grid-container">
-          <div class="grid-x grid-padding-x">
-            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
-            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
-            <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
+          <div class="grid-x grid-padding-x align-middle">
+            <div class="cell medium-3 text-center">
+              <div class="stat">128</div>
+              <small>Days without merge conflict</small>
+            </div>
+            <div class="cell medium-3 text-center">
+              <div class="stat">42%</div>
+              <small>Ultimate Question</small>
+            </div>
+            <div class="cell medium-3">
+              <ul>
+                <li><a href="#">Download link <small>(PDF)</small></a></li>
+                <li><a href="#">Website URL</a></li>
+                <li><a href="#">I wish this was machine readable <small>(PDF)</small></a></li>
+                <li><a href="#">Another link</a></li>
+              </ul>
+            </div>
             <div class="cell medium-3"><img src="http://via.placeholder.com/400"></div>
           </div>
         </div>
@@ -45,7 +52,9 @@
           </div>
         </div>
       </section>
+
       {{outlet}}
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR: 
- subs in sample statistics for 
  - basic stats below district header
  - "big number" (`.stat`)
  - list of links
- aligns stats vertically within the subsections
- adds a shadow on the site header to separate it from the scrollable area