### PR TITLE
Simplify Routes

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -13,14 +13,14 @@ export default Ember.Controller.extend({
 
   options: Ember.computed('model.features.@each', function() {
     let features = this.get('model.features');
-    return features.map(feature=> { 
+    return features.map(feature=> {
       let { cd, boro, borocd, neighborhoods } = feature.properties;
 
       if (neighborhoods) {
         neighborhoods = neighborhoods.join(',  ');
       }
 
-      return { 
+      return {
         cd,
         boro,
         borocd,
@@ -42,8 +42,8 @@ export default Ember.Controller.extend({
 
   actions: {
     handleClick(e) {
-      const { boro, borocd } = e.layer.feature.properties;
-      this.transitionToRoute('profile', boro.dasherize(), borocd);
+      const { boro, cd } = e.layer.feature.properties;
+      this.transitionToRoute('profile', boro.dasherize(), cd);
     },
     handleMouseover(e) {
       const { boro, cd } = e.layer.feature.properties;

--- a/app/router.js
+++ b/app/router.js
@@ -1,13 +1,13 @@
-import Ember from 'ember';
-import config from './config/environment';
+import Ember from 'ember'; // eslint-disable-line
+import config from './config/environment'; // eslint-disable-line
 
 const Router = Ember.Router.extend({
   location: config.locationType,
-  rootURL: config.rootURL
+  rootURL: config.rootURL,
 });
 
-Router.map(function() {
-  this.route('profile', { path: '/:boro/:name' }, function() { });
+Router.map(function () { // eslint-disable-line
+  this.route('profile', { path: '/:boro/:cd' }, () => {});
 });
 
 export default Router;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,40 +1,38 @@
-import Ember from 'ember';
+import Ember from 'ember'; // eslint-disable-line
 import neighborhoodsCrosswalk from '../utils/nabesCrosswalk';
+import carto from '../utils/carto';
 
-const SQL = " \
-  SELECT ST_Simplify(the_geom, 0.0005) AS the_geom, RIGHT(borocd::text, 2)::int as cd,\
-    CASE\
-      WHEN LEFT(borocd::text, 1) = '1' THEN 'Manhattan'\
-      WHEN LEFT(borocd::text, 1) = '2' THEN 'Bronx'\
-      WHEN LEFT(borocd::text, 1) = '3' THEN 'Brooklyn'\
-      WHEN LEFT(borocd::text, 1) = '4' THEN 'Queens'\
-      WHEN LEFT(borocd::text, 1) = '5' THEN 'Staten Island'\
-    END as boro,\
-    borocd\
-  FROM support_admin_cdboundaries\
-  ORDER BY boro, cd ASC\
-";
-const ENDPOINT = `https://cartoprod.capitalplanning.nyc/user/cpp/api/v2/sql?q=${SQL}&format=geojson`;
+const SQL = `
+  SELECT ST_Simplify(the_geom, 0.0005) AS the_geom, RIGHT(borocd::text, 2)::int as cd,
+    CASE
+      WHEN LEFT(borocd::text, 1) = '1' THEN 'Manhattan'
+      WHEN LEFT(borocd::text, 1) = '2' THEN 'Bronx'
+      WHEN LEFT(borocd::text, 1) = '3' THEN 'Brooklyn'
+      WHEN LEFT(borocd::text, 1) = '4' THEN 'Queens'
+      WHEN LEFT(borocd::text, 1) = '5' THEN 'Staten Island'
+    END as boro,
+    borocd
+  FROM support_admin_cdboundaries
+  ORDER BY boro, cd ASC
+`;
 
 export default Ember.Route.extend({
   model() {
-    return fetch(ENDPOINT)
-      .then(response => response.json())
-      .then((geojson) => {
-        return { 
-          type: geojson.type,
-          features: geojson.features.map((feature) => {
-            let borocd = feature.properties.borocd;
-            feature.properties.neighborhoods = neighborhoodsCrosswalk[borocd];
-            return feature;
-          }),
-        };
-      });
+    return carto.SQL(SQL, 'geojson')
+      .then(geojson => ({
+        type: geojson.type,
+        features: geojson.features.map((feature) => {
+          const borocd = feature.properties.borocd;
+          const thisFeature = feature;
+          thisFeature.properties.neighborhoods = neighborhoodsCrosswalk[borocd];
+          return thisFeature;
+        }),
+      }));
   },
 
   actions: {
     transitionToProfile(boro) {
-      this.transitionTo('profile', boro.boro.dasherize(), boro.borocd);
-    }
-  }
+      this.transitionTo('profile', boro.boro.dasherize(), boro.borocd % 100);
+    },
+  },
 });

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -1,22 +1,46 @@
-import Ember from 'ember';
-import { L } from 'ember-leaflet';
+import Ember from 'ember'; // eslint-disable-line
+import { L } from 'ember-leaflet'; // eslint-disable-line
 
 import carto from '../utils/carto';
+
+function buildBorocd(boro, cd) {
+  let borocode;
+  switch (boro) {
+    case 'manhattan':
+      borocode = 100;
+      break;
+    case 'bronx':
+      borocode = 200;
+      break;
+    case 'brooklyn':
+      borocode = 300;
+      break;
+    case 'queens':
+      borocode = 400;
+      break;
+    case 'staten-island':
+      borocode = 500;
+      break;
+    default:
+  }
+  return borocode + parseInt(cd, 10);
+}
 
 export default Ember.Route.extend({
   mapState: Ember.inject.service(),
   model(params) {
+    const { boro, cd } = params;
     return this.modelFor('application')
-      .features.find(district=>district.properties.borocd === parseInt(params.name));
+      .features.find(district => district.properties.borocd === buildBorocd(boro, cd));
   },
   afterModel(profile) {
-    let mapState = this.get('mapState');
+    const mapState = this.get('mapState');
     mapState.set('bounds', L.geoJson(profile.geometry).getBounds());
     mapState.set('geom', profile.geometry);
 
     carto.getTileTemplate()
-      .then(landUseTemplate => {
+      .then((landUseTemplate) => {
         mapState.set('landUseTemplate', landUseTemplate);
       });
-  }
+  },
 });

--- a/app/utils/carto.js
+++ b/app/utils/carto.js
@@ -1,18 +1,18 @@
-const carto_user = 'cpp';
-const carto_domain = 'cartoprod.capitalplanning.nyc';
+const cartoUser = 'cpp';
+const cartoDomain = 'cartoprod.capitalplanning.nyc';
 
-const buildTemplate = (layergroupid) => {
-  return `https://${carto_domain}/user/${carto_user}/api/v1/map/${layergroupid}/{z}/{x}/{y}.png`;
-}
+const buildTemplate = (layergroupid) => { // eslint-disable-line
+  return `https://${cartoDomain}/user/${cartoUser}/api/v1/map/${layergroupid}/{z}/{x}/{y}.png`;
+};
 
 const carto = {
-  SQL(query) {
+  SQL(query, type = 'json') {
     return new Promise((resolve, reject) => {
       $.ajax({
         type: 'GET',
-        url: `https://${carto_domain}/user/${carto_user}/api/v2/sql?q=${query}&format=json`,
+        url: `https://${cartoDomain}/user/${cartoUser}/api/v2/sql?q=${query}&format=${type}`,
         success(d) {
-          resolve(d.rows);
+          resolve(type === 'json' ? d.rows : d);
         },
       })
         .fail(() => reject());
@@ -95,16 +95,17 @@ const carto = {
     };
 
     return new Promise((resolve, reject) => {
-      fetch(`https://${carto_domain}/user/${carto_user}/api/v1/map`, {
+      fetch(`https://${cartoDomain}/user/${cartoUser}/api/v1/map`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(params),
       })
+        .catch(err => reject(err))
         .then(response => response.json())
         .then((json) => { resolve(buildTemplate(json.layergroupid)); });
-    })
+    });
   },
 };
 


### PR DESCRIPTION
This PR:
- Simplifies routes to match `{boroname}/{cd}`, added a helper function to create `borocd` from boroname and cd to the profile route can get the matching data.
- Removes `fetch` for top-level geojson data, uses `carto` util instead.
- Lots of eslint cleanup