### PR TITLE
modify initial SQL query to remove non-cds

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -3,7 +3,7 @@ import neighborhoodsCrosswalk from '../utils/nabesCrosswalk';
 import carto from '../utils/carto';
 
 const SQL = `
-  SELECT ST_Simplify(the_geom, 0.0005) AS the_geom, RIGHT(borocd::text, 2)::int as cd,
+  SELECT ST_Simplify(the_geom, 0.0005) AS the_geom, borocd %25 100 as cd,
     CASE
       WHEN LEFT(borocd::text, 1) = '1' THEN 'Manhattan'
       WHEN LEFT(borocd::text, 1) = '2' THEN 'Bronx'
@@ -13,6 +13,7 @@ const SQL = `
     END as boro,
     borocd
   FROM support_admin_cdboundaries
+  WHERE borocd %25 100 < 20 
   ORDER BY boro, cd ASC
 `;
 

--- a/app/utils/carto.js
+++ b/app/utils/carto.js
@@ -7,10 +7,11 @@ const buildTemplate = (layergroupid) => { // eslint-disable-line
 
 const carto = {
   SQL(query, type = 'json') {
+    const cleanedQuery = query.replace('\n', '');
     return new Promise((resolve, reject) => {
       $.ajax({
         type: 'GET',
-        url: `https://${cartoDomain}/user/${cartoUser}/api/v2/sql?q=${query}&format=${type}`,
+        url: `https://${cartoDomain}/user/${cartoUser}/api/v2/sql?q=${cleanedQuery}&format=${type}`,
         success(d) {
           resolve(type === 'json' ? d.rows : d);
         },


### PR DESCRIPTION
The PR modifies the initial SQL query that gets geojson for CDs, eliminating the non-cd results (central park, airports, etc)