### PR TITLE
move land use styles to module directory

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -31,11 +31,7 @@ $a11y-yellow: #ffeec1;
 @import 'modules/_m-ember-power-select';
 @import 'modules/_m-ember-tooltip';
 @import 'modules/_m-labs-beta-notice';
+@import 'modules/_m-section--land-use';
 @import 'modules/_m-section-menu';
 @import 'modules/_m-section';
 @import 'modules/_m-site-header';
-
-//
-// Land Use Map TODO: Move to Sass module
-// --------------------------------------------------
-@import 'land-use-map';

--- a/app/styles/modules/_m-section--land-use.scss
+++ b/app/styles/modules/_m-section--land-use.scss
@@ -55,10 +55,10 @@
 }
 
 @keyframes sk-bouncedelay {
-  0%, 80%, 100% { 
+  0%, 80%, 100% {
     -webkit-transform: scale(0);
     transform: scale(0);
-  } 40% { 
+  } 40% {
     -webkit-transform: scale(1.0);
     transform: scale(1.0);
   }

--- a/app/styles/modules/_m-section--land-use.scss
+++ b/app/styles/modules/_m-section--land-use.scss
@@ -1,6 +1,11 @@
 .leaflet-container.land-use-map {
   height: 400px;
   width: 100%;
+  margin-bottom: $global-margin;
+
+  @include breakpoint(medium) {
+    margin-bottom: 0;
+  }
 }
 
 .chart>.label {

--- a/app/styles/modules/_m-section.scss
+++ b/app/styles/modules/_m-section.scss
@@ -6,7 +6,7 @@
   margin-bottom: $global-margin*3;
 
   @include breakpoint(medium) {
-    .cell :last-child {
+    .cell > :last-child {
       margin-bottom: 0;
     }
   }


### PR DESCRIPTION
This PR:
- moves the Land Use styles into the `styles/modules` dir to be consistent with other files.
- adds margin bottom to the Land Use Map on small screens so it doesn't smash against the chart