### PR TITLE
79 printing

### DIFF
--- a/app/styles/_settings.scss
+++ b/app/styles/_settings.scss
@@ -96,7 +96,7 @@ $global-text-direction: ltr;
 $global-flexbox: true;
 $global-prototype-breakpoints: false;
 $global-color-pick-contrast-tolerance: 0;
-$print-transparent-backgrounds: true;
+$print-transparent-backgrounds: false;
 
 @include add-foundation-colors;
 
@@ -110,7 +110,7 @@ $breakpoints: (
   xlarge: 1200px,
   xxlarge: 1440px,
 );
-$print-breakpoint: large;
+$print-breakpoint: medium;
 $breakpoint-classes: (small medium large);
 
 // 3. The Grid

--- a/app/styles/_settings.scss
+++ b/app/styles/_settings.scss
@@ -110,7 +110,7 @@ $breakpoints: (
   xlarge: 1200px,
   xxlarge: 1440px,
 );
-$print-breakpoint: large;
+$print-breakpoint: medium;
 $breakpoint-classes: (small medium large xlarge);
 
 // 3. The Grid

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -24,6 +24,7 @@ $a11y-yellow: #ffeec1;
 // Layouts
 // --------------------------------------------------
 @import 'layouts/_l-default';
+@import 'layouts/_l-print';
 
 //
 // Modules

--- a/app/styles/layouts/_l-print.scss
+++ b/app/styles/layouts/_l-print.scss
@@ -1,0 +1,52 @@
+// --------------------------------------------------
+// Print styles
+// --------------------------------------------------
+
+// Add the .hide-for-print class to element that should not print
+
+@media print {
+
+  a[href]:after {
+    word-wrap: break-word !important;
+  }
+
+  .button {
+    background-color: transparent !important;
+    border: 1px solid $medium-gray !important;
+  }
+
+  .branding {
+
+    a {
+      text-decoration: none !important;
+
+      &[href]:after {
+        content: '' !important;
+      }
+    }
+  }
+
+  #cd-chooser .mapboxgl-map {
+    height: 250px !important;
+
+    a[href]:after {
+      content: '' !important;
+    }
+  }
+
+  .section-header {
+
+    a {
+      text-decoration: none !important;
+    }
+
+    .fa {
+      display: none !important;
+    }
+  }
+
+  .mapboxgl-ctrl-logo {
+    display: none !important;
+  }
+
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,5 +1,5 @@
 <a class="show-on-focus" href="#main">Skip to main content</a>
-<a href="https://planninglabs.nyc/" class="labs-beta-notice">A beta project of NYC Planning Labs</a>
+<a href="https://planninglabs.nyc/" class="labs-beta-notice hide-for-print">A beta project of NYC Planning Labs</a>
 <header role="banner" class="site-header">
   {{#initialize-foundation}}
   <div class="grid-x grid-padding-x">
@@ -8,9 +8,9 @@
       {{link-to 'Community Portal' 'index' classNames='site-name'}}
     </div>
     <div class="cell auto hide-for-large text-right">
-      <button class="responsive-nav-toggler" data-toggle="responsive-menu">Menu</button>
+      <button class="responsive-nav-toggler hide-for-print" data-toggle="responsive-menu">Menu</button>
     </div>
-    <div id="responsive-menu" class="cell large-shrink show-for-large" data-toggler=".show-for-large">
+    <div id="responsive-menu" class="cell large-shrink show-for-large hide-for-print" data-toggler=".show-for-large">
       <nav role="navigation">
         <ul class="menu">
           <li><a href="/about">About</a></li>
@@ -52,7 +52,7 @@
         </div>
       {{/if}}
     {{/mapbox-gl}}
-    <div id="cd-search">
+    <div id="cd-search" class="hide-for-print">
       {{#power-select
         options=options
         selected=selected

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -25,7 +25,7 @@
         </div>
       </div>
 
-      <div class="section-menu">
+      <div class="section-menu hide-for-print">
         {{#sticky-element top=97}}
           <ul class="menu">
             <li>{{scroll-to href='#needs' label='Needs'}}</li>


### PR DESCRIPTION
This PR closes #79 and: 
- turns off the `$print-transparent-backgrounds` settings var
- set the `$print-breakpoint` to `medium` (so that print CSS matches the single-column layout)
- adds a new print Sass file
- sets explicit `!important` CSS rules that style specific elements within `@media print { ... }`
- adds the `.hide-for-print` class to elements that shouldn't print (e.g. typeahead, section menu)