### PR TITLE
Routable anchors

### DIFF
--- a/app/components/scroll-to.js
+++ b/app/components/scroll-to.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+import ScrollTo from 'ember-scroll-to/components/scroll-to';
+
+export default ScrollTo.extend({
+  // ----- Events -----
+  scroll: Em.on('click', function(evt) {
+    evt.stopPropagation();
+    evt.preventDefault();
+
+    this
+      .get('scroller')
+      .scrollVertical(this.get('jQueryElement'), {
+        duration: this.get('duration'),
+        offset:   this.get('offset'),
+        easing:   this.get('easing'),
+        complete: () => Em.run(this, this.sendAction, 'afterScroll', this.get('href'), evt),
+      });
+  })
+});

--- a/app/controllers/profile.js
+++ b/app/controllers/profile.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   mapState: Ember.inject.service(),
+  queryParams: ['section'],
 
   columns: [
     'poverty_rate',
@@ -14,7 +15,14 @@ export default Ember.Controller.extend({
     'pct_served_parks',
   ],
 
+  section: '',
+
   d: Ember.computed('model', function () {
     return this.get('model.properties.dataprofile');
   }),
+  actions: {
+    handleAfterScroll(href, evt) {
+      this.set('section', href.replace('#', ''));
+    },
+  },
 });

--- a/app/routes/profile/index.js
+++ b/app/routes/profile/index.js
@@ -35,5 +35,8 @@ export default Ember.Route.extend({
         });
       }
     },
+    willTransition() {
+      this.controllerFor('profile').set('section', '');
+    }
   },
 });

--- a/app/routes/profile/index.js
+++ b/app/routes/profile/index.js
@@ -5,10 +5,12 @@ export default Ember.Route.extend({
     return this.modelFor('profile');
   },
   mapState: Ember.inject.service(),
+  scroller: Ember.inject.service(),
   actions: {
     didTransition() {
       let { cd, boro, borocd, neighborhoods } = this.controller.get('model.properties');
       let mapState = this.get('mapState');
+      const scroller = this.get('scroller');
 
       if (neighborhoods) {
         neighborhoods = neighborhoods.join(',  ');
@@ -23,6 +25,15 @@ export default Ember.Route.extend({
           neighborhoods,
         });
       });
-    }
-  }
+      
+      const section = this.paramsFor('profile').section;
+      if (section) {
+        Ember.run.next(this, () => {
+          scroller.scrollVertical(`#${section}`, {
+            offset: -35,
+          });
+        });
+      }
+    },
+  },
 });

--- a/app/styles/modules/_m-section.scss
+++ b/app/styles/modules/_m-section.scss
@@ -18,7 +18,7 @@
     color: $body-font-color;
 
     .fa {
-      color: $light-gray;
+      color: $medium-gray;
     }
   }
 

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -38,7 +38,11 @@
       </div>
 
       <section id="needs" class="page-section">
-        <h3 class="section-header"><a href="#needs">Community Needs {{fa-icon "link"}}</a></h3>
+        <h3 class="section-header">
+          {{#scroll-to offset=-35 href='#needs' afterScroll='handleAfterScroll'}}
+            Community Needs {{fa-icon "link"}}
+          {{/scroll-to}}
+        </h3>
 
         <div class="grid-container">
           <div class="grid-x grid-padding-x">
@@ -82,7 +86,11 @@
       </section>
 
       <section id="indicators" class="page-section">
-        <h3 class="section-header"><a href="#indicators">Indicators {{fa-icon "link"}}</a></h3>
+        <h3 class="section-header">
+          {{#scroll-to offset=-35 href='#indicators' afterScroll='handleAfterScroll'}}
+            Indicators {{fa-icon "link"}}
+          {{/scroll-to}}
+        </h3>
 
         <div class="grid-container">
           <div class="grid-x grid-padding-x">
@@ -271,7 +279,11 @@
       </section>
 
       <section id="built-environment" class="page-section">
-        <h3 class="section-header"><a href="#built-environment">Built Environment {{fa-icon "link"}}</a></h3>
+        <h3 class="section-header">
+          {{#scroll-to offset=-35 href='#built-environment' afterScroll='handleAfterScroll'}}
+            Built Environment {{fa-icon "link"}}
+          {{/scroll-to}}
+        </h3>
 
         <h4 class="header-tiny"><strong>Land Use</strong></h4>
         <div class="callout">
@@ -317,7 +329,11 @@
       </section>
 
       <section id="actions" class="page-section">
-        <h3 class="section-header"><a href="#actions">Actions {{fa-icon "link"}}</a></h3>
+        <h3 class="section-header">
+          {{#scroll-to offset=-35 href='#actions' afterScroll='handleAfterScroll'}}
+            Actions {{fa-icon "link"}}
+          {{/scroll-to}}
+        </h3>
 
         <div class="grid-container">
           <div class="grid-x grid-padding-x">
@@ -341,7 +357,11 @@
       </section>
 
       <section id="resources" class="page-section">
-        <h3 class="section-header"><a href="#resources">Resources {{fa-icon "link"}}</a></h3>
+        <h3 class="section-header">
+          {{#scroll-to offset=-35 href='#resources' afterScroll='handleAfterScroll'}}
+            Resources {{fa-icon "link"}}
+          {{/scroll-to}}
+        </h3>
 
         <div class="grid-container">
           <div class="grid-x grid-padding-x">

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -28,11 +28,11 @@
       <div class="section-menu hide-for-print">
         {{#sticky-element top=97}}
           <ul class="menu">
-            <li>{{scroll-to href='#needs' label='Needs'}}</li>
-            <li>{{scroll-to href='#indicators' label='Indicators'}}</li>
-            <li>{{scroll-to href='#built-environment' label='Built Environment'}}</li>
-            <li>{{scroll-to href='#actions' label='Actions'}}</li>
-            <li>{{scroll-to href='#resources' label='Resources'}}</li>
+            <li>{{scroll-to offset=-35 href='#needs' label='Needs' afterScroll='handleAfterScroll'}}</li>
+            <li>{{scroll-to offset=-35 href='#indicators' label='Indicators' afterScroll='handleAfterScroll'}}</li>
+            <li>{{scroll-to offset=-35 href='#built-environment' label='Built Environment' afterScroll='handleAfterScroll'}}</li>
+            <li>{{scroll-to offset=-35 href='#actions' label='Actions' afterScroll='handleAfterScroll'}}</li>
+            <li>{{scroll-to offset=-35 href='#resources' label='Resources' afterScroll='handleAfterScroll'}}</li>
           </ul>
         {{/sticky-element}}
       </div>

--- a/tests/integration/components/scroll-to-test.js
+++ b/tests/integration/components/scroll-to-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('scroll-to', 'Integration | Component | scroll to', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{scroll-to}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#scroll-to}}
+      template block text
+    {{/scroll-to}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
This PR makes scroll-to sections (needs, built environment, etc) RESTful by persisting current section in the URL and triggering the scroll-to event when transitioning into that route.

For example, a URL will look like this: `/queens/5?section=needs`. Once the page loads, the route will trigger a scrolling action through a service.

It resets the parameter on any transition to or between profiles. 

This also adds an offset to the scroll-to so the section title isn't missing.

@andycochran @chriswhong 


