### PR TITLE
Cw various fixes

### DIFF
--- a/app/components/facilities-section.js
+++ b/app/components/facilities-section.js
@@ -29,12 +29,10 @@ export default Ember.Component.extend({
 
   vectorSource: Ember.computed('facilitiesTemplate', function () {
     return carto.getTileTemplate(SQL)
-      .then((facilitiesTemplate) => {
-        return {
-          type: 'vector',
-          tiles: [facilitiesTemplate],
-        };
-      });
+      .then(facilitiesTemplate => ({
+        type: 'vector',
+        tiles: [facilitiesTemplate],
+      }));
   }),
 
   pointsLayer: {
@@ -67,7 +65,7 @@ export default Ember.Component.extend({
 
   sql: Ember.computed('borocd', function sql() {
     const borocd = this.get('borocd');
-    const SQL = `
+    const joinSql = `
       SELECT facdomain, count(facdomain)
       FROM facdb_facilities a
       INNER JOIN support_admin_cdboundaries b
@@ -76,7 +74,7 @@ export default Ember.Component.extend({
       GROUP BY facdomain
     `;
 
-    return SQL;
+    return joinSql;
   }),
 
   data: Ember.computed('sql', 'borocd', function() {
@@ -96,6 +94,10 @@ export default Ember.Component.extend({
       type: 'geojson',
       data: this.get('mapState.currentlySelected.geometry'),
     };
+  }),
+
+  centroid: Ember.computed('mapState', function () {
+    return this.get('mapState.centroid');
   }),
 
   cdSelectedLayer: {

--- a/app/components/land-use-chart.js
+++ b/app/components/land-use-chart.js
@@ -49,7 +49,28 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
     this.createChart();
   },
 
+  debouncedDidResize(width) {
+    this.set('width', width);
+    this.updateChart();
+  },
+
   createChart: function createChart() {
+    let svg = this.get('svg');
+
+    if (!svg) {
+      const el = this.$();
+      svg = d3.select(el.get(0)).append('svg')
+        .attr('class', 'chart');
+    }
+
+    this.set('svg', svg);
+    this.updateChart();
+  },
+
+  updateChart: function updateChart() {
+    const svg = this.get('svg');
+    const data = this.get('data');
+
     const el = this.$();
     const elWidth = el.width();
 
@@ -62,51 +83,31 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
     const height = 400 - margin.top - margin.bottom;
     const width = elWidth - margin.left - margin.right;
 
-    let svg = this.get('svg');
-
-    if (!svg) {
-      svg = d3.select(el.get(0)).append('svg')
-        .attr('class', 'chart');
-    }
-
     svg
       .attr('width', width + margin.left + margin.right)
       .attr('height', height + margin.top + margin.bottom);
 
-    this.set('svg', svg);
-    this.set('height', height);
-    this.set('width', width);
-
-    this.updateChart();
-  },
-
-  updateChart: function updateChart() {
-    const svg = this.get('svg');
-    const height = this.get('height');
-    const width = this.get('width');
-    const data = this.get('data');
-
-    data.then((data) => {
+    data.then((rawData) => {
       const y = d3.scaleBand()
-        .domain(data.map(d => d.landuse_desc))
+        .domain(rawData.map(d => d.landuse_desc))
         .range([0, height])
         .paddingOuter(0)
         .paddingInner(0.2);
 
       const x = d3.scaleLinear()
-        .domain([0, d3.max(data, d => d.percent)])
+        .domain([0, d3.max(rawData, d => d.percent)])
         .range([0, width]);
 
 
       const bars = svg.selectAll('.bar')
-        .data(data, d => d.landuse);
+        .data(rawData, d => d.landuse);
 
       bars.enter()
         .append('rect')
         .attr('class', 'bar')
         .attr('fill', d => landUseColors(d.landuse))
         .attr('x', 0)
-        .attr('height', y.bandwidth() - 12)
+        .attr('height', y.bandwidth() - 15)
         .attr('rx', 2)
         .attr('ry', 2)
         .attr('y', d => y(d.landuse_desc))
@@ -114,25 +115,25 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
 
 
       bars.transition().duration(300)
-        .attr('height', y.bandwidth() - 12)
+        .attr('height', y.bandwidth() - 15)
         .attr('y', d => y(d.landuse_desc))
         .attr('width', d => x(d.percent));
 
       bars.exit().remove();
 
       const labels = svg.selectAll('text')
-        .data(data, d => d.landuse);
+        .data(rawData, d => d.landuse);
 
       labels.enter().append('text')
         .attr('class', 'label')
         .attr('text-anchor', 'left')
         .attr('alignment-baseline', 'top')
         .attr('x', 0)
-        .attr('y', d => y(d.landuse_desc) + y.bandwidth())
+        .attr('y', d => y(d.landuse_desc) + y.bandwidth() + -3)
         .text(d => `${d.landuse_desc} | ${(d.percent * 100).toFixed(2)}%`);
 
       labels.transition().duration(300)
-        .attr('y', d => y(d.landuse_desc) + y.bandwidth())
+        .attr('y', d => y(d.landuse_desc) + y.bandwidth() + -3)
         .text(d => `${d.landuse_desc} | ${(d.percent * 100).toFixed(2)}%`);
 
       labels.exit().remove();

--- a/app/models/district.js
+++ b/app/models/district.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import DS from 'ember-data';
+import Ember from 'ember'; // eslint-disable-line
+import DS from 'ember-data'; // eslint-disable-line
 import neighborhoodsCrosswalk from '../utils/nabesCrosswalk';
-import bbox from 'npm:@turf/bbox';
+import bbox from 'npm:@turf/bbox' // eslint-disable-line
+import centroid from 'npm:@turf/centroid'; // eslint-disable-line
 
 export default DS.Model.extend({
   borocd: DS.attr('number'),
@@ -11,6 +12,10 @@ export default DS.Model.extend({
   bounds: Ember.computed('geometry', function() {
     const geometry = this.get('geometry');
     return bbox(geometry);
+  }),
+  centroid: Ember.computed('geometry', function() {
+    const geometry = this.get('geometry');
+    return centroid(geometry).geometry.coordinates;
   }),
   neighborhoods: Ember.computed('borocd', function() {
     const borocd = this.get('borocd');

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,10 +1,20 @@
 import Ember from 'ember'; // eslint-disable-line
+import bbox from 'npm:@turf/bbox'; // eslint-disable-line
 import toGeojson from '../utils/to-geojson';
 
 export default Ember.Route.extend({
+  mapState: Ember.inject.service(),
+
   model() {
     return this.store.findAll('district');
   },
+
+  afterModel(districts) {
+    const mapState = this.get('mapState');
+    const geojsonDistricts = toGeojson(districts);
+    mapState.set('bounds', bbox(geojsonDistricts));
+  },
+
 
   setupController(controller, districts) {
     this._super(controller, districts);

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,24 +1,11 @@
-import Ember from 'ember';
-import bbox from 'npm:@turf/bbox'; // eslint-disable-line
-import toGeojson from '../utils/to-geojson';
+import Ember from 'ember'; // eslint-disable-line
 
 export default Ember.Route.extend({
   mapState: Ember.inject.service(),
 
-  model() {
-    return this.modelFor('application');
-  },
-
-  afterModel(districts) {
-    const mapState = this.get('mapState');
-    const geojsonDistricts = toGeojson(districts);
-    mapState.set('bounds', bbox(geojsonDistricts));
-  },
-
   actions: {
     didTransition() {
-      let mapState = this.get('mapState');
-
+      const mapState = this.get('mapState');
       mapState.set('currentlySelected', null);
     },
   },

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -1,6 +1,5 @@
 import Ember from 'ember'; // eslint-disable-line
 import { L } from 'ember-leaflet'; // eslint-disable-line
-import bbox from 'npm:@turf/bbox'; // eslint-disable-line
 
 import carto from '../utils/carto';
 
@@ -45,8 +44,9 @@ export default Ember.Route.extend({
   },
   afterModel(district) {
     const mapState = this.get('mapState');
-    
+
     mapState.set('bounds', district.get('bounds'));
+    mapState.set('centroid', district.get('centroid'));
   },
   actions: {
     error(error) {

--- a/app/routes/profile/index.js
+++ b/app/routes/profile/index.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Ember from 'ember'; // eslint-disable-line
 
 export default Ember.Route.extend({
   mapState: Ember.inject.service(),

--- a/app/services/map-state.js
+++ b/app/services/map-state.js
@@ -1,9 +1,7 @@
 import Ember from 'ember'; // eslint-disable-line
-const DEFAULT_BOUNDS = [[40.690913, -74.077644], [40.856654, -73.832692]];
-
+const DEFAULT_BOUNDS = [-74.077644, 40.690913, -73.832692, 40.856654];
 
 export default Ember.Service.extend({
-  init() {},
   bounds: DEFAULT_BOUNDS,
   currentlySelected: null,
   mapInstance: null,

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -30,7 +30,6 @@
         {{source.layer layer=cdLineLayer}}
         {{source.layer layer=cdLabelLayer}}
       {{/map.source}}
-
       {{map.call 'fitBounds' mapState.bounds}}
       {{map.on 'click' (action 'handleClick')}}
       {{map.on 'mousemove' (action 'handleMouseover')}}

--- a/app/templates/components/facilities-section.hbs
+++ b/app/templates/components/facilities-section.hbs
@@ -39,6 +39,8 @@
           <small class="legend-dot-wrapper cell auto">{{data.facdomain}}</small>
         </p>
       {{/each}}
+      <hr/>
+      <p>View this area in the <a href="https://capitalplanning.nyc.gov/facilities/explorer#13.62/{{centroid.[1]}}/{{centroid.[0]}}" target="_blank">{{fa-icon "external-link"}} NYC Facilities Explorer</a></p>
     </div>
   </div>
   {{yield}}

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -133,7 +133,7 @@
                     </td>
                     <td class="text-center">
                       {{numeral-format d.pop_2010 '0.0a'}}
-                      ({{numeral-format d.pop_change_00_10 '0%'}})
+                      ({{numeral-format d.pop_change_00_10 '+0%'}})
                     </td>
                     <td class="text-center">
                       {{numeral-format d.pop_11_15_acs '0.0a'}}
@@ -156,10 +156,10 @@
                 <tbody>
                   <tr>
                     <td class="text-center">
-                      {{d.area_sqmi}}
+                      {{numeral-format d.area_sqmi '0.0'}}
                     </td>
                     <td class="text-center">
-                      {{d.acres}}
+                      {{numeral-format d.acres '0,0'}}
                     </td>
                   </tr>
                 </tbody>

--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"
   },
-  "private": true
+  "private": true,
+  "dependencies": {
+    "@turf/centroid": "^4.6.1"
+  }
 }


### PR DESCRIPTION
Various fixes for size 1 issues!

This PR addresses:
- #104 Fixes cut off text in land use chart
- #99 Makes land use chart re-render when the screen is resized
- #113 On "not found" route, the map shows the entire city, not Antarctica
- #96 Population change percentage is now signed 
- #103 Acreage is shown with a thousands separator, square miles as X.X
- #152 Facilities section includes a link to the facilities explorer with a composed URL including the centroid of the currently selected district