### PR TITLE
Cw persistent labels

### DIFF
--- a/app/components/needs-statements.js
+++ b/app/components/needs-statements.js
@@ -14,7 +14,6 @@ export default Ember.Component.extend({
 
     return this.get('allStatements')
       .then(statements=> {
-        console.log(statements);
         return statements.tree
           .filter(statement => statement.type === 'blob')
           .filter(statement => statement.path.indexOf(district.get('borocdAcronym')) !== -1)
@@ -29,7 +28,6 @@ export default Ember.Component.extend({
 
   truncatedYears: Ember.computed('district', 'showAll', function() {
     return this.get('availableYears').then(years => {
-      console.log(years);
       if(this.get('showAll')) {
         return years;
       } else {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -24,15 +24,16 @@ export default Ember.Controller.extend({
     };
   }),
 
-  cdLabelsBoro: {
+  cdBoroLabelLayer: {
+    id: 'cd-boro-label',
+    type: 'symbol',
+    source: 'cds',
+    minzoom: 11.5,
     layout: {
       'text-field': '{boro}',
+      'text-allow-overlap': true,
       'symbol-placement': 'point',
       'text-size': 12,
-      'icon-allow-overlap': false,
-      'icon-ignore-placement': false,
-      'icon-optional': false,
-      'symbol-avoid-edges': true,
       'text-offset': [0, -2.5],
     },
   },
@@ -73,6 +74,7 @@ export default Ember.Controller.extend({
     source: 'cds',
     layout: {
       'text-field': '{cd}',
+      'text-allow-overlap': true,
       'symbol-placement': 'point',
       'text-size': {
         stops: [
@@ -80,10 +82,6 @@ export default Ember.Controller.extend({
           [12, 30],
         ],
       },
-      'icon-allow-overlap': false,
-      'icon-ignore-placement': false,
-      'icon-optional': false,
-      'symbol-avoid-edges': true,
     },
     paint: {
       'text-color': 'rgba(66, 66, 66, 1)',

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -26,6 +26,13 @@ export default Ember.Controller.extend({
     };
   }),
 
+  cdHoveredSource: Ember.computed('mapState.currentlyHovered', function () {
+    return {
+      type: 'geojson',
+      data: this.get('mapState.currentlyHovered'),
+    };
+  }),
+
   cdBoroLabelLayer: {
     id: 'cd-boro-label',
     type: 'symbol',
@@ -110,12 +117,11 @@ export default Ember.Controller.extend({
   cdHoveredLayer: {
     id: 'cd-hovered',
     type: 'fill',
-    source: 'cds',
+    source: 'cd-hovered',
     paint: {
       'fill-color': '#cdcdcd',
       'fill-opacity': 0.5,
     },
-    filter: ['==', 'borocd', 0],
   },
 
   mouseoverLocation: null,
@@ -150,22 +156,23 @@ export default Ember.Controller.extend({
         this.transitionToRoute('profile', boro.dasherize(), cd);
       }
     },
-    handleMouseover(e) {
+    handleMousemove(e) {
       const map = e.target;
+      const mapState = this.get('mapState');
       const firstCD = map.queryRenderedFeatures(e.point, { layers: ['cd-fill'] })[0];
 
       if (firstCD) {
         if (isCdLayer(firstCD.layer.source)) {
-          map.setFilter('cd-hovered', ['==', 'borocd', firstCD.properties.borocd]);
+          mapState.set('currentlyHovered', firstCD);
           map.getCanvas().style.cursor = 'pointer';
-        } else {
-          map.getCanvas().style.cursor = '';
         }
+      } else {
+        this.set('mouseoverLocation', null);
+        mapState.set('currentlyHovered', null);
+        map.getCanvas().style.cursor = '';
       }
     },
-    handleMouseleave() {
-      this.set('mouseoverLocation', null);
-    },
+
     handleMapLoad(map) {
       map.addControl(new mapboxgl.NavigationControl(), 'top-left');
 

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -8,6 +8,8 @@ export default Ember.Controller.extend({
   lng: -74,
   zoom: 9.2,
 
+  hoveredCD: '',
+
   geojson: {},
 
   cdSource: Ember.computed('geojson', function () {
@@ -88,10 +90,21 @@ export default Ember.Controller.extend({
     },
   },
 
+  cdHoveredLayer: {
+    id: 'cd-hovered',
+    type: 'fill',
+    source: 'cds',
+    paint: {
+      'fill-color': '#cdcdcd',
+      'fill-opacity': 0.5,
+    },
+    filter: ['==', 'borocd', 0],
+  },
+
   mouseoverLocation: null,
   'tooltip-text': '',
 
-  style: Ember.computed('mapState.currentlySelected', function style() {
+  style: Ember.computed('mapState.currentlySelected', function() {
     return (geoJsonFeature) => {
       if (geoJsonFeature.properties.borocd === this.get('mapState.currentlySelected.borocd')) {
         return {
@@ -121,13 +134,15 @@ export default Ember.Controller.extend({
       }
     },
     handleMouseover(e) {
-      const firstCD = e.target.queryRenderedFeatures(e.point, { layers: ['cd-fill'] })[0];
+      const map = e.target;
+      const firstCD = map.queryRenderedFeatures(e.point, { layers: ['cd-fill'] })[0];
 
       if (firstCD) {
         if (isCdLayer(firstCD.layer.source)) {
-          e.target.getCanvas().style.cursor = 'pointer';
+          map.setFilter('cd-hovered', ['==', 'borocd', firstCD.properties.borocd]);
+          map.getCanvas().style.cursor = 'pointer';
         } else {
-          e.target.getCanvas().style.cursor = '';
+          map.getCanvas().style.cursor = '';
         }
       }
     },

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -18,7 +18,6 @@ export default Ember.Route.extend({
 
   setupController(controller, districts) {
     this._super(controller, districts);
-    console.log('districts', districts);
     controller.set('geojson', toGeojson(districts));
   },
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -18,6 +18,7 @@ export default Ember.Route.extend({
 
   setupController(controller, districts) {
     this._super(controller, districts);
+    console.log('districts', districts);
     controller.set('geojson', toGeojson(districts));
   },
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -8,6 +8,7 @@
         {{source.layer layer=cdFillLayer}}
         {{source.layer layer=cdLineLayer}}
         {{source.layer layer=cdLabelLayer}}
+        {{source.layer layer=cdBoroLabelLayer}}
       {{/map.source}}
       {{map.call 'fitBounds' mapState.bounds}}
       {{map.on 'click' (action 'handleClick')}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -6,6 +6,7 @@
     {{#mapbox-gl id='map' initOptions=(hash style='mapbox://styles/mapbox/light-v9' zoom=zoom center=(array lng lat)) mapLoaded=(action 'handleMapLoad') as |map|}}
       {{#map.source sourceId='cds' source=cdSource as |source|}}
         {{source.layer layer=cdFillLayer}}
+        {{source.layer layer=cdHoveredLayer}}
         {{source.layer layer=cdLineLayer}}
         {{source.layer layer=cdLabelLayer}}
         {{source.layer layer=cdBoroLabelLayer}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -4,17 +4,23 @@
 <div id="main" class="grid-x">
   <div class="cell large-4 xlarge-3" id="cd-chooser">
     {{#mapbox-gl id='map' initOptions=(hash style='mapbox://styles/mapbox/light-v9' zoom=zoom center=(array lng lat)) mapLoaded=(action 'handleMapLoad') as |map|}}
+
       {{#map.source sourceId='cds' source=cdSource as |source|}}
         {{source.layer layer=cdFillLayer}}
-        {{source.layer layer=cdHoveredLayer}}
         {{source.layer layer=cdLineLayer}}
         {{source.layer layer=cdLabelLayer}}
         {{source.layer layer=cdBoroLabelLayer}}
       {{/map.source}}
+
+      {{#if mapState.currentlyHovered}}
+        {{#map.source sourceId='cd-hovered' source=cdHoveredSource as |source|}}
+          {{source.layer layer=cdHoveredLayer}}
+        {{/map.source}}
+      {{/if}}
+
       {{map.call 'fitBounds' mapState.bounds}}
       {{map.on 'click' (action 'handleClick')}}
-      {{map.on 'mousemove' (action 'handleMouseover')}}
-      {{map.on 'mouseout' (action 'handleMouseleave')}}
+      {{map.on 'mousemove' (action 'handleMousemove')}}
       {{#if mapState.currentlySelected}}
         {{#map.source sourceId='currentlySelected' source=cdSelectedSource as |source|}}
           {{source.layer layer=cdSelectedLayer}}
@@ -31,7 +37,7 @@
       {{/if}}
     {{/mapbox-gl}}
     <div id="cd-search" class="hide-for-print">
-      {{navigation-dropdown 
+      {{navigation-dropdown
           model=model
           selected=mapState.currentlySelected
           onchange=(route-action 'transitionToProfile')}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1619,12 +1619,6 @@
         "to-utf8": "0.0.1"
       }
     },
-    "bower": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
-      "integrity": "sha1-Vdvr7wrZFVOC2enT5JfBNyNFtEo=",
-      "dev": true
-    },
     "bower-config": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.0.tgz",
@@ -4012,7 +4006,6 @@
       "requires": {
         "amd-name-resolver": "0.0.6",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "bower": "1.8.0",
         "bower-config": "1.4.0",
         "bower-endpoint-parser": "0.2.2",
         "broccoli-babel-transpiler": "6.1.1",


### PR DESCRIPTION
This PR addresses:
- #144, making sure the CD labels in the main map ignore collisions and remain visible
- Adds a small borough name above the CD number when zoomed in past level 11.5
- #142, adding a subtle gray highlight to CDs on mouseover, which will make it clearer that it can be clicked (and that non-CD areas cannot be clicked)
