### PR TITLE
Removed time frame from poverty indicator summary

### DIFF
--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -114,7 +114,7 @@
                             cd_stat=d.poverty_rate
                             boro_stat=d.poverty_rate_boro
                             city_stat=d.poverty_rate_nyc}}
-            of residents had incomes below the poverty level in the last 12 months
+            of residents have incomes below the poverty level
           {{/data.indicator}}
           {{#data.indicator class="indicator cell medium-6 large-12 xlarge-6" name='Educational Attainment'
                             column='pct_bach_deg'


### PR DESCRIPTION
Per the Population team, the best way to avoid confusion around what time frame this ACS 5-year estimate refers to is to remove "in the last 12 months" from the summary.