### PR TITLE
revise the chart legend

### DIFF
--- a/app/styles/modules/_m-charts.scss
+++ b/app/styles/modules/_m-charts.scss
@@ -17,11 +17,26 @@
 }
 
 .chart-legend {
+  font-size: rem-calc(12);
+  font-weight: $global-weight-normal;
   display: block;
-  position: absolute;
-  right: 0;
-  top: 10px;
-  margin-top: 8px;
+  padding-top: 0.5rem;
+
+  @include breakpoint(medium) {
+    float: right;
+  }
+
+  span {
+    display: inline-block;
+    width: 0.5em;
+    height: 1em;
+  }
+  .estimate {
+    background-color: #A8A8A8;
+  }
+  .moe {
+    border-top: 0.375em solid #ACE8FF;
+  }
 }
 
 .moe-text {

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -24,24 +24,13 @@
           {{#scroll-to offset=-210 href='#indicators' afterScroll='handleAfterScroll'}}
             {{fa-icon "bar-chart"}} Indicators {{fa-icon "link"}}
           {{/scroll-to}}
+          <span class="chart-legend">
+            <span class="estimate"></span>&nbsp;Estimate
+            &nbsp;
+            <span class="moe"></span>&nbsp;Margin of Error
+          </span>
         </h3>
-        <svg class="chart-legend" width="80" height="100">
-          <g class="callouts">
-            <text x="22" y="5.7" font-size="5">
-              Margin of Error
-            </text>
-            <text x="22" y="28" font-size="5">
-              Estimate
-            </text>
-            <line x1="8" y1="4.8" x2="20" y2="4.8" stroke-width=".5" stroke="black"></line>
-            <line x1="8" y1="26" x2="20" y2="26" stroke-width=".5" stroke="black"></line>
-          </g>
-          <g class="bars">
-            <rect class="bar bar-203 bar-index-0" fill="rgb(168, 168, 168)" y="4.8" width="5.828389830508475" x="0" height="48.1359649122807"></rect></g>
-          <g class="moes">
-            <rect class="bar moe bar-203 bar-index-0" fill="#6eceff" y="0" width="5.828389830508475" x="0" height="10" style="opacity: 0.5;"></rect>
-          </g>
-        </svg>
+
         <div class="grid-x grid-padding-x">
           <div class="cell medium-6 xlarge-5">
 
@@ -117,7 +106,7 @@
           </div>
         </div>
 
-        {{#key-indicators class="key-indicators grid-x grid-padding-x"                  
+        {{#key-indicators class="key-indicators grid-x grid-padding-x"
                           indicators=columns
                           boro=model.boro
                           cd=model.cd


### PR DESCRIPTION
This PR moves the chart legend from an SVG into `<span>` elements and CSS, using a slimmer responsive style. 