### PR TITLE
Implement studies and plans component

### DIFF
--- a/app/components/studies-and-plans.js
+++ b/app/components/studies-and-plans.js
@@ -1,0 +1,14 @@
+import Ember from 'ember'; // eslint-disable-line
+import carto from '../utils/carto';
+
+export default Ember.Component.extend({
+  district: null,
+  studies: Ember.computed('district', function() {
+    const borocd = this.get('district.borocd');
+    const SQL = `SELECT * FROM cdprofiles_studies_plans WHERE cd LIKE '%25${borocd}%25'`;
+    return carto.SQL(SQL, 'json')
+      .then((json) => {
+        return json;
+      });
+  }),
+});

--- a/app/templates/components/studies-and-plans.hbs
+++ b/app/templates/components/studies-and-plans.hbs
@@ -1,0 +1,17 @@
+{{#if (await studies) as |resolvedStudies|}}
+  {{#if resolvedStudies.length}}
+    <ul class="no-bullet">
+    {{#each resolvedStudies as |study|}}
+      {{log study}}
+      <li class="list-item-padded">
+        <a href = "{{study.url}}">{{fa-icon "external-link"}}&nbsp;<strong>{{study.name}}</strong></a>
+      </li>
+    {{/each}}
+    </ul>
+  {{/if}}
+  {{else}}
+  <p class="text-center" style="padding: 60px 0;">No recent or ongoing studies.</p>
+{{/if}}
+<a class="button small hollow expanded no-margin" href="https://www1.nyc.gov/site/planning/plans/places.page">View all NYC Studies</a>
+
+{{yield}}

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -311,8 +311,9 @@
           </div>
           <div class="cell medium-6 large-4 xlarge-5">
 
-            <h4 class="subsection-header"><strong>Neighborhood Studies</strong></h4>
+            <h4 class="subsection-header"><strong>Neighborhood Studies & Plans</strong></h4>
             <div class="callout">
+              {{studies-and-plans district=model}}
             </div>
 
           </div>

--- a/tests/integration/components/studies-and-plans-test.js
+++ b/tests/integration/components/studies-and-plans-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('studies-and-plans', 'Integration | Component | studies and plans', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{studies-and-plans}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#studies-and-plans}}
+      template block text
+    {{/studies-and-plans}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
This PR adds a "Studies and Plans" section.

The data are in a new table in carto called `cdprofile_studies_plans` and the query just searches for a match of the `borocd` in a column that contains a list of CDs that match a plan.

Closes #205