### PR TITLE
Better Indicators Grid

### DIFF
--- a/app/components/ranking-chart.js
+++ b/app/components/ranking-chart.js
@@ -83,7 +83,6 @@ export default Ember.Component.extend(ResizeAware, {
       const moe = this.get('moe');
       const rank = data.findIndex(d => d.is_selected);
       const unit = this.get('unit');
-      const numeral_format = this.get('numeral_format');
 
       if(!data[0][column]) return;
 
@@ -117,7 +116,7 @@ export default Ember.Component.extend(ResizeAware, {
       };
 
       const percent = (number) => {
-        return numeral(number).format(numeral_format);
+        return numeral(number).format('0.0');
       };
 
       const tooltipTemplate = function(d) {

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -183,6 +183,41 @@ html, body {
   }
 }
 
+.indicator-grid {
+  @include xy-grid();
+  @include xy-gutters($callout-padding*2, margin, right left, true);
+
+  .indicator-cell--stat {
+    @include xy-cell-static(7, true, $callout-padding*2);
+    @include breakpoint(large) {
+      @include xy-cell-static(4, true, $callout-padding*2);
+    }
+    @include breakpoint(xlarge) {
+      @include xy-cell-static(6, true, $callout-padding*2);
+    }
+  }
+
+  .indicator-cell--borocity {
+    @include xy-cell-static(5, true, $callout-padding*2);
+    @include breakpoint(large) {
+      @include xy-cell-static(3, true, $callout-padding*2);
+    }
+    @include breakpoint(xlarge) {
+      @include xy-cell-static(6, true, $callout-padding*2);
+    }
+  }
+
+  .indicator-cell--chart {
+    @include xy-cell-static(12, true, $callout-padding*2);
+    @include breakpoint(large) {
+      @include xy-cell-static(5, true, $callout-padding*2);
+    }
+    @include breakpoint(xlarge) {
+      @include xy-cell-static(12, true, $callout-padding*2);
+    }
+  }
+}
+
 
 //
 // Layout helper classes

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -151,6 +151,40 @@ html, body {
 
 
 //
+// Key Indicators
+// --------------------------------------------------
+
+.key-indicators {
+  @include xy-grid();
+  @include xy-gutters($grid-margin-gutters, margin, right left, true);
+
+  .indicator {
+    @include xy-cell(12);
+
+    @include breakpoint(medium) {
+      @include xy-cell(6);
+    }
+
+    @include breakpoint(large) {
+      @include xy-cell(12);
+    }
+
+    @include breakpoint(xlarge) {
+      @include xy-cell(6);
+    }
+
+    @include breakpoint(90em) {
+      @include xy-cell-static($size:4, $gutter-output:true, $gutters:40px);
+    }
+
+    .stat-footer {
+      min-height: 3.5em;
+    }
+  }
+}
+
+
+//
 // Layout helper classes
 // --------------------------------------------------
 .relative {

--- a/app/templates/components/key-indicator.hbs
+++ b/app/templates/components/key-indicator.hbs
@@ -1,15 +1,15 @@
 <h4 class="subsection-header"><strong>{{name}}{{#if tip}}{{info-tooltip tip=tip}}{{/if}}</strong></h4>
 <div class="callout">
-  <div class="grid-x grid-padding-x align-middle">
-    <div class="cell small-7 large-4 xlarge-7 text-center">
+  <div class="indicator-grid">
+    <div class="indicator-cell--stat text-center">
       <span class="stat">{{numeral-format cd_stat numeral_format}}{{unit}}</span>
       <small class="stat-footer">{{yield}}</small>
     </div>
-    <div class="cell small-5 large-3 xlarge-5 text-right large-text-left xlarge-text-right">
+    <div class="indicator-cell--borocity text-right large-text-left xlarge-text-right">
       {{#if boro_stat}}<span class="boro-stat label">{{boro}}: <strong>{{numeral-format boro_stat numeral_format}}{{unit}}</strong></span>{{/if}}
       {{#if city_stat}}<span class="city-stat label">NYC: <strong>{{numeral-format city_stat numeral_format}}{{unit}}</strong></span>{{/if}}
     </div>
-    <div class="cell auto">
+    <div class="indicator-cell--chart">
       {{ranking-chart
         data=sortedData
         ranked=borocd

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -87,12 +87,12 @@
           </div>
         </div>
 
-        {{#key-indicators class="key-indicators grid-x grid-padding-x"
+        {{#key-indicators class="key-indicators"
                           indicators=columns
                           boro=model.boro
                           cd=model.cd
                           borocd=d.borocd as |data|}}
-          {{#data.indicator class="indicator cell medium-6 large-12 xlarge-6" name='Rent Burden'
+          {{#data.indicator class="indicator" name='Rent Burden'
                             column='pct_hh_rent_burd'
                             moe='moe_hh_rent_burd'
                             tip=d.acs_tooltip
@@ -102,14 +102,14 @@
                             city_stat=d.pct_hh_rent_burd_nyc}}
             of households spend 35% or more of their income on rent
           {{/data.indicator}}
-          {{#data.indicator class="indicator cell medium-6 large-12 xlarge-6" name='Access to Parks'
+          {{#data.indicator class="indicator" name='Access to Parks'
                             column='pct_served_parks'
                             unit='%'
                             tip='New York City Department of Parks & Recreation, 2016. DPR considers walking distance to be 1/4 mile for parks less than 6 acres, and 1/2 mile for larger parks and pools.'
                             cd_stat=d.pct_served_parks}}
             of residents live within <a href="https://www.nycgovparks.org/planning-and-building/planning/walk-to-a-park">walking distance of a park or open space</a>
           {{/data.indicator}}
-          {{#data.indicator class="indicator cell medium-6 large-12 xlarge-6" name='Mean Commute to Work'
+          {{#data.indicator class="indicator" name='Mean Commute to Work'
                             column='mean_commute'
                             moe='moe_mean_commute'
                             tip=d.acs_tooltip
@@ -118,7 +118,7 @@
                             city_stat=d.mean_commute_nyc}}
             minutes
           {{/data.indicator}}
-          {{#data.indicator class="indicator cell medium-6 large-12 xlarge-6" name='Street Cleanliness'
+          {{#data.indicator class="indicator" name='Street Cleanliness'
                             column='pct_clean_strts'
                             unit='%'
                             tip='New York City Department of Sanitation, 2017'
@@ -127,7 +127,7 @@
                             city_stat=d.pct_clean_strts_nyc}}
             of streets were rated "acceptable"on the <a href="https://www1.nyc.gov/site/operations/performance/scorecard-street-sidewalk-cleanliness-ratings.page">Street Cleanliness Scorecard</a> in FY 2016
           {{/data.indicator}}
-          {{#data.indicator class="indicator cell medium-6 large-12 xlarge-6" name='Crime Rate'
+          {{#data.indicator class="indicator" name='Crime Rate'
                             column='crime_per_1000'
                             tip='NYPD Complaint Data, 2016'
                             cd_stat=d.crime_per_1000
@@ -135,7 +135,7 @@
                             city_stat=d.crime_per_1000_nyc}}
             major crimes were reported per 1,000 residents in 2016
           {{/data.indicator}}
-          {{#data.indicator class="indicator cell medium-6 large-12 xlarge-6" name='Educational Attainment'
+          {{#data.indicator class="indicator" name='Educational Attainment'
                             column='pct_bach_deg'
                             moe='moe_bach_deg'
                             tip=d.acs_tooltip
@@ -145,7 +145,7 @@
                             city_stat=d.pct_bach_deg_nyc}}
             of residents 25 years or older have earned a bachelor's degree or higher
           {{/data.indicator}}
-          {{#data.indicator class="indicator cell medium-6 large-12 xlarge-6" name='Unemployment'
+          {{#data.indicator class="indicator" name='Unemployment'
                             column='unemployment_cd'
                             moe='moe_unemployment_cd'
                             tip=d.acs_tooltip
@@ -155,7 +155,7 @@
                             city_stat=d.unemployment_nyc}}
             of the civilian labor force is unemployed
           {{/data.indicator}}
-          {{#data.indicator class="indicator cell medium-6 large-12 xlarge-6" name='Poverty'
+          {{#data.indicator class="indicator" name='Poverty'
                             column='poverty_rate'
                             moe='moe_poverty_rate'
                             tip=d.acs_tooltip


### PR DESCRIPTION
This PR… 
- Add a semantically-built grid for the Key Indicators, putting them in 3 columns on xxlarge screens
- Add a semantically-built grid INSIDE each Key Indicator, using slimmer gutters and aligning the boro/city stats to the top
- Undoes a failed attempt from [9c2eddb](https://github.com/NYCPlanning/labs-community-portal/commit/9c2eddb63aef53c83aa332b28fd62204d67c2970#diff-1261b61ea71be1650ad201b1b892b7deL119) in which I tried to format the number in the ranking chart tooltip (This number is always formatted `0.0` and needs to use the indicator's `numeral_format` parameter.)