### PR TITLE
refactor lucats for new endpoint

### DIFF
--- a/app/components/lucats-list.js
+++ b/app/components/lucats-list.js
@@ -11,7 +11,11 @@ export default Ember.Component.extend({
     return fetch(URL)
       .then(data => data.json())
       .then((data) => {
-        data.forEach((d) => {
+        data.active.forEach((d) => {
+          d.projectName = d.projectName !== '' ? d.projectName : 'Unnamed Project'; // eslint-disable-line
+        });
+
+        data.completed.forEach((d) => {
           d.projectName = d.projectName !== '' ? d.projectName : 'Unnamed Project'; // eslint-disable-line
         });
 

--- a/app/templates/components/lucats-list.hbs
+++ b/app/templates/components/lucats-list.hbs
@@ -1,18 +1,38 @@
 {{#if (await projects) as |resolvedProjects|}}
-  {{#if resolvedProjects.length}}
+  {{#if resolvedProjects}}
+    Active Applications
+    {{#if resolvedProjects.active.length}}
     <ul class="no-bullet xlarge-2-column">
-    {{#each resolvedProjects as |project|}}
+    {{#each resolvedProjects.active as |project|}}
       <li class="list-item-padded">
-        <a href = "http://a030-lucats.nyc.gov/lucats/DirectAccess.aspx?ULURPNO={{project.landUseId}}">{{fa-icon "external-link"}}&nbsp;<strong>{{project.projectName}}</strong></a>
+        <a href = "http://a030-lucats.nyc.gov/lucats/DirectAccess.aspx?ULURPNO={{project.landUseId}}" target="_blank">{{fa-icon "external-link"}}&nbsp;<strong>{{project.projectName}}</strong></a>
         <small class="list--link-meta">{{project.landUseReceivedDate}} | {{project.location}}</small>
       </li>
     {{/each}}
     </ul>
-    <a class="button small hollow expanded no-margin" href="http://a030-lucats.nyc.gov/lucats/DirectULURPCD.aspx?Boro={{district.boroAcronym}}&CD={{district.cd}}">View all on LUCATS</a>
+    {{else}}
+    <p class="text-center" style="padding: 60px 0;">No active applications found.</p>
+    {{/if}}
+
+    Completed Applications
+    {{#if resolvedProjects.completed.length}}
+    <ul class="no-bullet xlarge-2-column">
+    {{#each resolvedProjects.completed as |project|}}
+      <li class="list-item-padded">
+        <a href = "http://a030-lucats.nyc.gov/lucats/DirectAccess.aspx?ULURPNO={{project.landUseId}}" target="_blank">{{fa-icon "external-link"}}&nbsp;<strong>{{project.projectName}}</strong></a>
+        <small class="list--link-meta">{{project.landUseReceivedDate}} | {{project.location}}</small>
+      </li>
+    {{/each}}
+    </ul>
+    {{else}}
+    <p class="text-center" style="padding: 60px 0;">No completed applications found.</p>
+    {{/if}}
+
+    <a class="button small hollow expanded no-margin" href="http://a030-lucats.nyc.gov/lucats/DirectULURPCD.aspx?Boro={{district.boroAcronym}}&CD={{district.cd}}" target="_blank">View all on LUCATS</a>
   {{/if}}
   {{else}}
   <p class="text-center" style="padding: 60px 0;">No applications found.</p>
-  <a class="button small hollow expanded no-margin" href="http://a030-lucats.nyc.gov/lucats/welcome.aspx">Search LUCATS</a>
+  <a class="button small hollow expanded no-margin" href="http://a030-lucats.nyc.gov/lucats/welcome.aspx" target="_blank">Search LUCATS</a>
 
 {{/if}}
 {{yield}}


### PR DESCRIPTION
This PR incorporates a new lucats proxy format which breaks down applications data into `active` and `completed`.  

This branch needs some design love before it can be merged @andycochran.

Since the new lucats proxy is getting up to 20 results of each type, we may have 40 applications on the screen.  We should maybe only show 10 of each OR only show active and refer people to LUCATS for anything else.