### PR TITLE
add pop and mass floodplain info

### DIFF
--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -270,22 +270,51 @@
             {{fa-icon "tint"}} Waterfront Resiliency {{fa-icon "link"}}
           {{/scroll-to}}
         </h3>
-        <p class="section-header-description"> The maps and charts below provide detailed information regarding the people and built environment in NYC’s floodplain. This information helps the City and community members better understand a neighborhood’s risk and key characteristics that influence the ability of a neighborhood to adapt.  For more information on flood hazards and City Planning’s resiliency work program, please visit the <a href = "http://dcp.maps.arcgis.com/apps/webappviewer/index.html?id=1c37d271fba14163bbb520517153d6d5">NYC Flood Hazard Mapper</a> and <a href="https://nyc.gov/resilientneighborhoods">nyc.gov/resilientneighborhoods</a>.</p>
+        <p class="section-header-description">The information below details the people and built environment within NYC’s floodplain, showing the risk and key characteristics that influence the ability of a neighborhood to adapt. The current floodplain based on FEMA 2015 Preliminary Flood Insurance Rate Maps (PFIRM). The 2050s floodplain is based on FEMA’s Preliminary Flood Insurance Rate Map data and the New York Panel on Climate Change’s 90th Percentile Projections for Sea-Level Rise. For more information on flood hazards and City Planning’s resiliency work program, please visit the <a href = "http://dcp.maps.arcgis.com/apps/webappviewer/index.html?id=1c37d271fba14163bbb520517153d6d5">NYC Flood Hazard Mapper</a> and <a href="https://nyc.gov/resilientneighborhoods">nyc.gov/resilientneighborhoods</a>.</p>
 
-        <div class="grid-x grid-padding-x">
+        <div class="grid-x grid-padding-x align-middle">
           <div class="cell xlarge-6">
-            <h4 class="subsection-header"><strong>Floodplain Map</strong></h4>
+            <h4 class="subsection-header"><strong>Floodplain</strong></h4>
             <div class="callout">
               {{waterfront-map}}
             </div>
           </div>
-          <div class="cell medium-6 xlarge-3">
+          <div class="cell xlarge-6">
+            <h4 class="subsection-header"><strong>Population in Floodplain</strong></h4>
+            <div class="callout">
+              <div class="grid-x grid-margin-x align-middle">
+                <div class="cell small-6 text-center">
+                  <span class="stat">{{numeral-format d.current_fp_pop '0.0a'}}</span>
+                  <span class="stat-footer">Current Floodplain<br /><small class="dark-gray">2010 Census</small></span>
+                </div>
+                <div class="cell small-6 text-center">
+                  <span class="stat">{{numeral-format d.future_fp_pop '0.0a'}}</span>
+                  <span class="stat-footer">2050s Floodplain<br /><small class="dark-gray">2010 Census</small></span>
+                </div>
+              </div>
+            </div>
+
+            <h4 class="subsection-header"><strong>Land Mass in Floodplain</strong></h4>
+            <div class="callout">
+              <div class="grid-x grid-margin-x align-middle">
+                <div class="cell small-6 text-center">
+                  <span class="stat">{{numeral-format d.current_fp_area '0,000.0'}}</span>
+                  <span class="stat-footer">Square Miles in Current Floodplain</span>
+                </div>
+                <div class="cell small-6 text-center">
+                  <span class="stat">{{numeral-format d.future_fp_area '0,000.0'}}</span>
+                  <span class="stat-footer">Square Miles in 2050s Floodplain</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="cell medium-6">
             <h4 class="subsection-header"><strong>Buildings in Floodplain {{info-tooltip tip="Counts of buildings on lots that intersect with the 2015 PFIRM"}}</strong></h4>
             <div class="callout">
               {{waterfront-chart property='numbldgs' borocd=model.borocd}}
             </div>
           </div>
-          <div class="cell medium-6 xlarge-3">
+          <div class="cell medium-6">
             <h4 class="subsection-header"><strong>Dwelling Units in Floodplain {{info-tooltip tip="Counts of residential units on lots that intersect with the 2015 PRIFM"}}</strong></h4>
             <div class="callout">
               {{waterfront-chart property='unitsres' borocd=model.borocd}}


### PR DESCRIPTION
This PR…
- adds current/future floodplain population info to the Waterfront Resiliency section 
- adds current/future floodplain land mass info to the Waterfront Resiliency section 
- adjust the Waterfront Resiliency section, putting the charts below the map, into wider columns

Closes #287. 