### PR TITLE
Use ember concurrency for zoning-chart component data

### DIFF
--- a/app/components/zoning-chart.js
+++ b/app/components/zoning-chart.js
@@ -1,5 +1,6 @@
 import Ember from 'ember'; // eslint-disable-line
 import ResizeAware from 'ember-resize/mixins/resize-aware'; // eslint-disable-line
+import { Promise } from 'rsvp';
 
 import carto from '../utils/carto';
 
@@ -69,7 +70,7 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
     this.updateChart();
   },
 
-  createChart: function createChart() {
+  createChart() {
     let svg = this.get('svg');
 
     if (!svg) {
@@ -82,7 +83,7 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
     this.updateChart();
   },
 
-  updateChart: function updateChart() {
+  updateChart() {
     const svg = this.get('svg');
     const data = this.get('data');
 
@@ -102,21 +103,20 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
       .attr('width', width + margin.left + margin.right)
       .attr('height', height + margin.top + margin.bottom);
 
-    data.then((rawData) => {
-
+    if (data) {
       const y = d3.scaleBand()
-        .domain(rawData.map(d => d.zonedist))
+        .domain(data.map(d => d.zonedist))
         .range([0, height])
         .paddingOuter(0)
         .paddingInner(0.2);
 
       const x = d3.scaleLinear()
-        .domain([0, d3.max(rawData, d => d.percent)])
+        .domain([0, d3.max(data, d => d.percent)])
         .range([0, width]);
 
 
       const bars = svg.selectAll('.bar')
-        .data(rawData, d => d.zonedist);
+        .data(data, d => d.zonedist);
 
       bars.enter()
         .append('rect')
@@ -138,7 +138,7 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
       bars.exit().remove();
 
       const labels = svg.selectAll('text')
-        .data(rawData, d => d.zonedist);
+        .data(data, d => d.zonedist);
 
       labels.enter().append('text')
         .attr('class', 'label')
@@ -159,7 +159,7 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
         });
 
       labels.exit().remove();
-    });
+    };
   },
 });
 

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -70,8 +70,10 @@ export default Ember.Route.extend({
   afterModel(district) {
     const mapState = this.get('mapState');
 
-    mapState.set('bounds', district.get('bounds'));
-    mapState.set('centroid', district.get('centroid'));
+    mapState.setProperties({
+      bounds: district.get('bounds'),
+      centroid: district.get('centroid'),
+    });
   },
   setupController(controller, district) {
     this._super(...arguments);

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -1,6 +1,6 @@
 import Ember from 'ember'; // eslint-disable-line
 import { L } from 'ember-leaflet'; // eslint-disable-line
-
+import { task } from 'ember-concurrency';
 import carto from '../utils/carto';
 
 function buildBorocd(boro, cd) {
@@ -26,6 +26,31 @@ function buildBorocd(boro, cd) {
   return borocode + parseInt(cd, 10);
 }
 
+function generateZoningSQL(borocd) {
+  const SQL = `
+    WITH zones as (
+      SELECT ST_Intersection(ST_MakeValid(a.the_geom), ST_MakeValid(b.the_geom)) as the_geom, zonedist
+      FROM support_zoning_zd a, support_admin_cdboundaries b
+      WHERE ST_intersects(ST_MakeValid(a.the_geom), ST_MakeValid(b.the_geom))
+      AND b.borocd = '${borocd}'
+    ),
+    totalsm AS (
+      SELECT sum(ST_Area(the_geom::geography)) as total
+      FROM zones
+    )
+
+  SELECT sum(percent) as percent, zonedist FROM (
+      SELECT  ROUND((sum(ST_Area(the_geom::geography))/totalsm.total)::numeric,4) as percent, LEFT(zonedist, 1) as zonedist
+    FROM zones, totalsm
+    GROUP BY zonedist, totalsm.total
+    ORDER BY percent DESC
+  ) x
+  GROUP BY zonedist
+`;
+
+  return SQL;
+}
+
 export default Ember.Route.extend({
   mapState: Ember.inject.service(),
   model(params) {
@@ -48,8 +73,22 @@ export default Ember.Route.extend({
     mapState.set('bounds', district.get('bounds'));
     mapState.set('centroid', district.get('centroid'));
   },
+  setupController(controller, district) {
+    this._super(...arguments);
+
+    const borocd = district.get('borocd');
+    const zoningData = this.get('zoningData').perform(borocd, controller);
+    controller.setProperties({
+      zoningData,
+    });
+  },
+
+  zoningData: task(function * (borocd, controller) {
+    return carto.SQL(generateZoningSQL(borocd));
+  }).restartable(),
+
   actions: {
-    error(error) {
+    error() {
       this.transitionTo('/not-found');
     },
   },

--- a/app/templates/components/zoning-chart.hbs
+++ b/app/templates/components/zoning-chart.hbs
@@ -1,4 +1,4 @@
-{{#if (is-pending data)}}
+{{#if loading}}
   <div class="spinner-wrapper loading">
     <div class="spinner">
       <div class="bounce1"></div>

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -225,7 +225,10 @@
               {{zoning-map borocd=model.borocd}}
             </div>
             <div class="cell medium-6">
-              {{zoning-chart borocd=model.borocd}}
+              {{zoning-chart 
+                  borocd=model.borocd 
+                  data=zoningData.value
+                  loading=zoningData.isRunning}}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Race conditions in zoning chart led to wrong data being displayed (some queries take longer than others - resolving promises that took longer are always the last to update the component). This commit introduces ember concurrency into the mix by setting up tasks for the data fetching process. The task restarts itself when a route transition occurs.

Closes #260. 