### PR TITLE
make maps jumpto instead of animating

### DIFF
--- a/app/components/facilities-section.js
+++ b/app/components/facilities-section.js
@@ -1,5 +1,6 @@
 import Ember from 'ember'; // eslint-disable-line
 import mapboxgl from 'mapbox-gl'; // eslint-disable-line
+import geoViewport from 'npm:@mapbox/geo-viewport'; // eslint-disable-line
 
 import carto from '../utils/carto';
 
@@ -20,11 +21,20 @@ const SQL = `
 export default Ember.Component.extend({
   borocd: '',
 
-  initOptions: {
-    style: 'mapbox://styles/mapbox/light-v9',
-    zoom: 9,
-    center: [-74, 40.7071],
-    scrollZoom: false,
+  initOptions: Ember.computed('mapState', function() {
+    const { bounds } = this.get('mapState');
+    const { center, zoom } = geoViewport.viewport(bounds, [400, 400]);
+    return {
+      style: 'mapbox://styles/mapbox/light-v9',
+      center,
+      zoom,
+      scrollZoom: false,
+    };
+  }),
+
+  fitBoundsOptions: {
+    linear: true,
+    duration: 0,
   },
 
   vectorSource: Ember.computed('facilitiesTemplate', function () {

--- a/app/components/land-use-map.js
+++ b/app/components/land-use-map.js
@@ -9,6 +9,11 @@ export default Ember.Component.extend({
     scrollZoom: false,
   },
 
+  fitBoundsOptions: {
+    linear: true,
+    duration: 0,
+  },
+
   vectorSource: {
     type: 'vector',
     tiles: ['https://tiles.planninglabs.nyc/pluto/{z}/{x}/{y}/tile.mvt'],

--- a/app/components/waterfront-map.js
+++ b/app/components/waterfront-map.js
@@ -45,7 +45,14 @@ export default FacilitiesSection.extend({
         tiles: [template],
       }));
   }),
+
+  fitBoundsOptions: {
+    linear: true,
+    duration: 0,
+  },
+
   pfirm15Layer,
+
   floodplain2050Layer,
 
   rasterSource: {

--- a/app/components/zoning-map.js
+++ b/app/components/zoning-map.js
@@ -79,8 +79,16 @@ export default FacilitiesSection.extend({
         tiles: [zoningTemplate],
       }));
   }),
+
+  fitBoundsOptions: {
+    linear: true,
+    duration: 0,
+  },
+
   pointsLayer: zdConfig,
+
   zoningLabelsLayer: zdLabelConfig,
+
   actions: {
     handleMouseover(e) {
       const feature = e.target.queryRenderedFeatures(e.point, { layers: ['zoning'] })[0];

--- a/app/templates/components/facilities-section.hbs
+++ b/app/templates/components/facilities-section.hbs
@@ -8,7 +8,7 @@
         {{/map.source}}
       {{/with}}
 
-      {{map.call 'fitBounds' mapState.bounds}}
+      {{map.call 'fitBounds' mapState.bounds fitBoundsOptions}}
       {{map.on 'mousemove' (action 'handleMouseover')}}
       {{map.on 'mouseout' (action 'handleMouseleave')}}
       {{map.on 'click' (action 'handleClick')}}

--- a/app/templates/components/land-use-map.hbs
+++ b/app/templates/components/land-use-map.hbs
@@ -7,7 +7,7 @@
     {{source.layer layer=rasterLayer before='waterway-label'}}
   {{/map.source}}
 
-  {{map.call 'fitBounds' mapState.bounds}}
+  {{map.call 'fitBounds' mapState.bounds fitBoundsOptions}}
   {{map.on 'mousemove' (action 'handleMouseover')}}
   {{map.on 'mouseout' (action 'handleMouseleave')}}
 

--- a/app/templates/components/waterfront-map.hbs
+++ b/app/templates/components/waterfront-map.hbs
@@ -6,7 +6,7 @@
       {{source.layer layer=pfirm15Layer before='aeroway-polygon'}}
     {{/map.source}}
 
-    {{map.call 'fitBounds' mapState.bounds}}
+    {{map.call 'fitBounds' mapState.bounds fitBoundsOptions}}
 
     {{#if mapState.currentlySelected}}
       {{#map.source sourceId='currentlySelected' source=cdSelectedSource as |source|}}

--- a/app/templates/components/zoning-map.hbs
+++ b/app/templates/components/zoning-map.hbs
@@ -12,7 +12,7 @@
       {{/if}}
     {{/with}}
 
-    {{map.call 'fitBounds' mapState.bounds}}
+    {{map.call 'fitBounds' mapState.bounds fitBoundsOptions}}
     {{map.on 'mousemove' (action 'handleMouseover')}}
     {{map.on 'mouseout' (action 'handleMouseleave')}}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,6 +134,14 @@
         "@glimmer/util": "0.22.3"
       }
     },
+    "@mapbox/geo-viewport": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geo-viewport/-/geo-viewport-0.2.2.tgz",
+      "integrity": "sha1-kyBsBEI4whpg/KfpBkyM5j6AJ7Q=",
+      "requires": {
+        "@mapbox/sphericalmercator": "1.0.5"
+      }
+    },
     "@mapbox/gl-matrix": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/gl-matrix/-/gl-matrix-0.0.1.tgz",
@@ -145,6 +153,11 @@
       "resolved": "https://registry.npmjs.org/@mapbox/shelf-pack/-/shelf-pack-3.0.0.tgz",
       "integrity": "sha1-ROKEyDNu7aHp27sdYZVMcOJuV2Y=",
       "dev": true
+    },
+    "@mapbox/sphericalmercator": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz",
+      "integrity": "sha1-cCN7l3QJXtHP286nqP0fyCsmkfI="
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "private": true,
   "dependencies": {
+    "@mapbox/geo-viewport": "^0.2.2",
     "@turf/boolean-contains": "^4.6.1",
     "@turf/centroid": "^4.6.1",
     "@turf/inside": "^4.6.0",


### PR DESCRIPTION
This PR makes the supporting maps jumpTo() a location instantly instead of animating when `fitBounds()` is called.  In theory this will help avoid unnecessary async calls for tiles.