### PR TITLE
use github raw json files instead of carto calls

### DIFF
--- a/app/components/building-age-chart.js
+++ b/app/components/building-age-chart.js
@@ -1,7 +1,8 @@
 import Ember from 'ember'; // eslint-disable-line
+import fetch from 'fetch'; // eslint-disable-line
 import ResizeAware from 'ember-resize/mixins/resize-aware'; // eslint-disable-line
+import githubraw from '../utils/githubraw';
 
-import carto from '../utils/carto';
 
 const BuildingAgeChart = Ember.Component.extend(ResizeAware, {
   classNames: ['relative'],
@@ -39,8 +40,8 @@ const BuildingAgeChart = Ember.Component.extend(ResizeAware, {
   }),
 
   data: Ember.computed('sql', 'borocd', function() {
-    const sql = this.get('sql');
-    return carto.SQL(sql);
+    const borocd = this.get('borocd');
+    return githubraw('building_age', borocd);
   }),
 });
 

--- a/app/components/building-age-chart.js
+++ b/app/components/building-age-chart.js
@@ -7,38 +7,6 @@ import githubraw from '../utils/githubraw';
 const BuildingAgeChart = Ember.Component.extend(ResizeAware, {
   classNames: ['relative'],
   borocd: '',
-  sql: Ember.computed('borocd', function sql() {
-    const borocd = this.get('borocd');
-    const SQL = `
-    SELECT
-      sum(numbldgs) as value, building_age as group,
-      ROUND(count(building_age)::numeric / totalbuildings, 4) AS value_pct
-    FROM (
-      SELECT
-      CASE
-        WHEN yearbuilt > 0 AND yearbuilt < 1961  THEN 'Pre-1961'
-        WHEN yearbuilt >= 1961 AND YearBuilt < 1983 THEN '1961-1982'
-        WHEN yearbuilt >= 1983 AND YearBuilt < 2013 THEN '1983-2012'
-        WHEN yearbuilt >= 2013 THEN '2013-Present'
-        ELSE 'Unknown'
-      END AS building_age,
-      numbldgs,
-      SUM (numbldgs) OVER () as totalbuildings
-      FROM support_mappluto a
-      INNER JOIN support_admin_cdboundaries b
-      ON ST_Contains(b.the_geom, a.the_geom)
-      AND b.borocd = '${borocd}'
-      INNER JOIN support_waterfront_pfirm15 c
-      ON ST_Intersects(a.the_geom, c.the_geom)
-      AND (fld_zone = 'AE' OR fld_zone = 'VE')
-    ) x
-    GROUP BY building_age, totalbuildings
-    ORDER BY array_position(array['Pre-1961','1961-1982','1983-2012','2013-Present','Unknown'], building_age)
-    `;
-
-    return SQL;
-  }),
-
   data: Ember.computed('sql', 'borocd', function() {
     const borocd = this.get('borocd');
     return githubraw('building_age', borocd);

--- a/app/components/building-type-chart.js
+++ b/app/components/building-type-chart.js
@@ -1,7 +1,6 @@
 import Ember from 'ember'; // eslint-disable-line
 import ResizeAware from 'ember-resize/mixins/resize-aware'; // eslint-disable-line
-
-import carto from '../utils/carto';
+import githubraw from '../utils/githubraw';
 
 function getColor(group) {
   const colorMap = {
@@ -63,10 +62,14 @@ const BuildingTypeChart = Ember.Component.extend(ResizeAware, {
     return SQL;
   }),
 
-  data: Ember.computed('sql', 'borocd', function() {
-    const sql = this.get('sql');
-    return carto.SQL(sql)
+  data: Ember.computed('property', 'borocd', function() {
+    const borocd = this.get('borocd');
+    const property = this.get('property');
+    const filler = property === 'numbldgs' ? 'buildings' : 'units';
+    const id = `building_type_${filler}`;
+    return githubraw(id, borocd)
       .then((data) => {
+        console.log('DATA', data)
         return data.map((d) => {
           const colorAdded = d;
           colorAdded.color = getColor(d.group);

--- a/app/components/building-type-chart.js
+++ b/app/components/building-type-chart.js
@@ -25,43 +25,6 @@ const BuildingTypeChart = Ember.Component.extend(ResizeAware, {
   loading: false,
   property: '', // one of 'numbldgs' or 'unitsres' passed in to component
   borocd: '',
-  sql: Ember.computed('borocd', function sql() {
-    const borocd = this.get('borocd');
-    const property = this.get('property');
-    const SQL = `
-      SELECT
-      SUM(${property}) as value,
-     building_typology as group,
-     ROUND(SUM(${property})::numeric / propertytotal, 4) AS value_pct
-      FROM (
-        SELECT
-          ${property},
-        CASE
-
-          WHEN (unitsres < 3 AND unitsres > 0) AND (comarea = 0 AND officearea = 0 AND retailarea = 0 AND factryarea = 0) THEN '1-2 Family'
-          WHEN (unitsres < 6 AND unitsres > 2) AND (numfloors < 5) AND (comarea = 0 AND officearea = 0 AND retailarea = 0 AND factryarea = 0) THEN 'Small Apartment Buildings'
-          WHEN (unitsres >= 6 AND numfloors >= 5) AND (comarea = 0 AND officearea = 0 AND retailarea = 0 AND factryarea = 0) THEN 'Big Apartment Buildings'
-          WHEN (unitsres > 2) AND (comarea > 0 OR officearea > 0 OR retailarea > 0 OR factryarea > 0) THEN 'Mixed-Use Apartment Buildings'
-          WHEN (unitsres = 0) AND (comarea > 0 OR officearea > 0 OR retailarea > 0) AND factryarea = 0 THEN 'Commercial Buildings'
-          WHEN (unitsres = 0) AND factryarea > 0 THEN 'Manufacturing Buildings'
-          ELSE 'Public facilities, utilities and other buildings'
-        END AS building_typology,
-        SUM (${property}) OVER () as propertytotal
-        FROM support_mappluto a
-        INNER JOIN support_admin_cdboundaries b
-        ON ST_Contains(b.the_geom, a.the_geom)
-        AND b.borocd = '${borocd}'
-        INNER JOIN support_waterfront_pfirm15 c
-        ON ST_Intersects(a.the_geom, c.the_geom)
-        AND (fld_zone = 'AE' OR fld_zone = 'VE')
-      ) x
-      GROUP BY building_typology, propertytotal
-      ORDER BY SUM(${property}) DESC
-    `;
-
-    return SQL;
-  }),
-
   data: Ember.computed('property', 'borocd', function() {
     const borocd = this.get('borocd');
     const property = this.get('property');

--- a/app/components/subgrade-chart.js
+++ b/app/components/subgrade-chart.js
@@ -5,35 +5,6 @@ import githubraw from '../utils/githubraw';
 const LandUseChart = Ember.Component.extend(ResizeAware, {
   classNames: ['relative'],
   borocd: '',
-  sql: Ember.computed('borocd', function sql() {
-    const borocd = this.get('borocd');
-    const SQL = `
-    SELECT
-      count(subgrade_space) AS value, subgrade_space AS group
-    FROM (
-    SELECT
-      CASE
-        WHEN landuse IN ('01','02','03') AND bsmtcode IN ('2','4') THEN 'Residential, full basement below grade'
-    WHEN landuse IN ('04','05','06','07','08','09','10','11') AND bsmtcode IN ('2','4') THEN 'Non-residential, full basement below grade'
-        WHEN landuse IN ('01','02','03','04','05','06','07','08','09','10','11') AND bsmtcode = '5' THEN 'Sturcture with Unknown Basement Type'
-      END AS subgrade_space,
-      SUM (numbldgs) OVER () as totalbuildings
-      FROM support_mappluto a
-      INNER JOIN support_admin_cdboundaries b
-      ON ST_Contains(b.the_geom, a.the_geom)
-      AND b.borocd = '${borocd}'
-      INNER JOIN support_waterfront_pfirm15 c
-      ON ST_Intersects(a.the_geom, c.the_geom)
-      AND (fld_zone = 'AE' OR fld_zone = 'VE')
-        ) x
-    WHERE subgrade_space IS NOT NULL
-    GROUP BY subgrade_space
-    ORDER BY array_position(array['Residential, full basement below grade', 'Non-residential, full basement below grade', 'Sturcture with Unknown Basement Type'], subgrade_space)
-
-    `;
-
-    return SQL;
-  }),
 
   data: Ember.computed('sql', 'borocd', function() {
     const borocd = this.get('borocd');

--- a/app/components/subgrade-chart.js
+++ b/app/components/subgrade-chart.js
@@ -1,7 +1,6 @@
 import Ember from 'ember'; // eslint-disable-line
 import ResizeAware from 'ember-resize/mixins/resize-aware'; // eslint-disable-line
-
-import carto from '../utils/carto';
+import githubraw from '../utils/githubraw';
 
 const LandUseChart = Ember.Component.extend(ResizeAware, {
   classNames: ['relative'],
@@ -37,8 +36,8 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
   }),
 
   data: Ember.computed('sql', 'borocd', function() {
-    const sql = this.get('sql');
-    return carto.SQL(sql);
+    const borocd = this.get('borocd');
+    return githubraw('subgrade_space', borocd);
   }),
 });
 

--- a/app/components/zoning-chart.js
+++ b/app/components/zoning-chart.js
@@ -1,8 +1,7 @@
 import Ember from 'ember'; // eslint-disable-line
 import ResizeAware from 'ember-resize/mixins/resize-aware'; // eslint-disable-line
-import { Promise } from 'rsvp';
-
-import carto from '../utils/carto';
+import { Promise } from 'rsvp'; // eslint-disable-line
+import githubraw from '../utils/githubraw';
 
 const colors = function(zonedist) {
   if (zonedist === 'R') return '#F3F88F';
@@ -57,8 +56,8 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
   }),
 
   data: Ember.computed('sql', 'borocd', function() {
-    const sql = this.get('sql');
-    return carto.SQL(sql);
+    const borocd = this.get('borocd');
+    return githubraw('zoning', borocd);
   }),
 
   didRender() {
@@ -148,18 +147,18 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
         .attr('y', d => y(d.zonedist) + y.bandwidth() + -3)
         .text((d) => {
           const description = descriptions(d.zonedist);
-          return `${description} | ${(d.percent * 100).toFixed(2)}%`
+          return `${description} | ${(d.percent * 100).toFixed(2)}%`;
         });
 
       labels.transition().duration(300)
         .attr('y', d => y(d.zonedist) + y.bandwidth() + -3)
         .text((d) => {
           const description = descriptions(d.zonedist);
-          return `${description} | ${(d.percent * 100).toFixed(2)}%`
+          return `${description} | ${(d.percent * 100).toFixed(2)}%`;
         });
 
       labels.exit().remove();
-    };
+    }
   },
 });
 

--- a/app/components/zoning-chart.js
+++ b/app/components/zoning-chart.js
@@ -29,31 +29,6 @@ const LandUseChart = Ember.Component.extend(ResizeAware, {
   loading: false,
 
   borocd: '',
-  sql: Ember.computed('borocd', function sql() {
-    const borocd = this.get('borocd');
-    const SQL = `
-      WITH zones as (
-        SELECT ST_Intersection(ST_MakeValid(a.the_geom), ST_MakeValid(b.the_geom)) as the_geom, zonedist
-        FROM support_zoning_zd a, support_admin_cdboundaries b
-        WHERE ST_intersects(ST_MakeValid(a.the_geom), ST_MakeValid(b.the_geom))
-        AND b.borocd = '${borocd}'
-      ),
-      totalsm AS (
-        SELECT sum(ST_Area(the_geom::geography)) as total
-        FROM zones
-      )
-
-    SELECT sum(percent) as percent, zonedist FROM (
-        SELECT  ROUND((sum(ST_Area(the_geom::geography))/totalsm.total)::numeric,4) as percent, LEFT(zonedist, 1) as zonedist
-      FROM zones, totalsm
-      GROUP BY zonedist, totalsm.total
-      ORDER BY percent DESC
-    ) x
-    GROUP BY zonedist
-  `;
-
-    return SQL;
-  }),
 
   data: Ember.computed('sql', 'borocd', function() {
     const borocd = this.get('borocd');

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -2,6 +2,7 @@ import Ember from 'ember'; // eslint-disable-line
 import { L } from 'ember-leaflet'; // eslint-disable-line
 import { task } from 'ember-concurrency';
 import ScrollToTop from '../mixins/scroll-to-top';
+import githubraw from '../utils/githubraw';
 
 import carto from '../utils/carto';
 
@@ -89,7 +90,7 @@ export default Ember.Route.extend(ScrollToTop, {
   },
 
   zoningData: task(function * (borocd, controller) {
-    return carto.SQL(generateZoningSQL(borocd));
+    return githubraw('zoning', borocd)
   }).restartable(),
 
   actions: {

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -29,31 +29,6 @@ function buildBorocd(boro, cd) {
   return borocode + parseInt(cd, 10);
 }
 
-function generateZoningSQL(borocd) {
-  const SQL = `
-    WITH zones as (
-      SELECT ST_Intersection(ST_MakeValid(a.the_geom), ST_MakeValid(b.the_geom)) as the_geom, zonedist
-      FROM support_zoning_zd a, support_admin_cdboundaries b
-      WHERE ST_intersects(ST_MakeValid(a.the_geom), ST_MakeValid(b.the_geom))
-      AND b.borocd = '${borocd}'
-    ),
-    totalsm AS (
-      SELECT sum(ST_Area(the_geom::geography)) as total
-      FROM zones
-    )
-
-  SELECT sum(percent) as percent, zonedist FROM (
-      SELECT  ROUND((sum(ST_Area(the_geom::geography))/totalsm.total)::numeric,4) as percent, LEFT(zonedist, 1) as zonedist
-    FROM zones, totalsm
-    GROUP BY zonedist, totalsm.total
-    ORDER BY percent DESC
-  ) x
-  GROUP BY zonedist
-`;
-
-  return SQL;
-}
-
 export default Ember.Route.extend(ScrollToTop, {
 
   mapState: Ember.inject.service(),

--- a/app/utils/githubraw.js
+++ b/app/utils/githubraw.js
@@ -1,0 +1,8 @@
+import fetch from 'fetch'; // eslint-disable-line
+
+export default function githubraw(id, borocd) {
+  const URL = `https://raw.githubusercontent.com/NYCPlanning/labs-community-data/master/data/${id}/${borocd}.json`;
+
+  return fetch(URL)
+    .then(data => data.json());
+}

--- a/tests/unit/utils/githubraw-test.js
+++ b/tests/unit/utils/githubraw-test.js
@@ -1,0 +1,10 @@
+import githubraw from 'labs-community-portal/utils/githubraw';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | githubraw');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = githubraw();
+  assert.ok(result);
+});


### PR DESCRIPTION
This PR replaces calls to the carto API for the following charts:
- building age in floodplain
- building type in floodplain
- residential units in floodplain
- subgrade space in floodplain
- zoning

The SQL and raw files are in [labs-community-data](https://github.com/nycplanning/labs-community-data)
