### PR TITLE
About section links

### DIFF
--- a/app/controllers/about.js
+++ b/app/controllers/about.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: ['section'],
+  section: '',
+});

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -11,7 +11,7 @@ export default Ember.Route.extend(ScrollToTop, SetMapBounds, {
     didTransition() {
       const scroller = this.get('scroller');
       const section = this.paramsFor('about').section;
-      console.log(this.paramsFor('about'));
+
       if (section) {
         Ember.run.next(this, () => {
           scroller.scrollVertical(`#${section}`, {

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -15,7 +15,7 @@ export default Ember.Route.extend(ScrollToTop, SetMapBounds, {
       if (section) {
         Ember.run.next(this, () => {
           scroller.scrollVertical(`#${section}`, {
-            offset: -210,
+            offset: -115,
           });
         });
       }

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -3,7 +3,22 @@ import SetMapBounds from '../mixins/set-map-bounds';
 import ScrollToTop from '../mixins/scroll-to-top';
 
 export default Ember.Route.extend(ScrollToTop, SetMapBounds, {
+  scroller: Ember.inject.service(),
   model() {
     return this.modelFor('application');
+  },
+  actions: {
+    didTransition() {
+      const scroller = this.get('scroller');
+      const section = this.paramsFor('about').section;
+      console.log(this.paramsFor('about'));
+      if (section) {
+        Ember.run.next(this, () => {
+          scroller.scrollVertical(`#${section}`, {
+            offset: -210,
+          });
+        });
+      }
+    },
   },
 });

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -8,7 +8,7 @@
 
     <h2>What's included in each profile?</h2>
 
-    <h3>{{fa-icon "bar-chart"}} Indicators</h3>
+    <h3 id="indicators">{{fa-icon "bar-chart"}} Indicators</h3>
 
     <div class="grid-x grid-padding-x">
       <div class="cell xlarge-7">
@@ -27,7 +27,7 @@
       </div>
     </div>
 
-    <h3>{{fa-icon "building"}} The Built Environment</h3>
+    <h3 id="built-environment">{{fa-icon "building"}} The Built Environment</h3>
 
     <div class="grid-x grid-padding-x">
       <div class="cell xlarge-7">
@@ -44,17 +44,23 @@
       </div>
     </div>
 
-    <h3>{{fa-icon "group"}} Community Board Perspectives</h3>
+    <h3 id="floodplain">{{fa-icon "tint"}} Floodplain</h3>
+
+    <p>The counts for "Age of Buildings in Floodplain" are grouped based on important dates in the history of NYC’s land-use and floodplain regulation. 1961 marked the establishment of the city’s current zoning resolution, 1983 marked the adoption of Flood Insurance Rate Maps for the first time, and 2013 included the creation of revised Flood Insurance Rate Maps and the adoption of special zoning regulations for flood hazard areas.</p>
+
+    <p>Basements are among the most flood vulnerable areas of a building, so it is important to understand where they exist and what uses or mechanical systems they may contain.</p>
+
+    <h3 id="community-board">{{fa-icon "group"}} Community Board Perspectives</h3>
 
     <p>Each community board is charged with advocating for the unique priorities of its district in collaboration with city agencies. Among their many responsibilities, community boards prepare an annual Statement of Community District Needs and Community Board Budget Requests, which aim to assess the district’s most pressing needs and prioritize capital project and service expenses in the City’s budget. City Planning facilitates the preparation of these documents, and each district’s profile on this website includes statements for fiscal year 2018 and up to ten years prior. A full archive will be available online soon. To request a statement that is not currently available through these profiles, contact <a href="mailto:portal_dl@planning.nyc.gov">portal_dl@planning.nyc.gov</a>.</p>
 
-    <h3>{{fa-icon "calendar"}} Projects</h3>
+    <h3 id="projects">{{fa-icon "calendar"}} Projects</h3>
 
     <p>This section presents a summary of the Department of City Planning’s activities in each district. In Recent Land Use Applications, you will find a live look at active and completed land use and environmental review applications in each district from our Land Use &amp; CEQR Application Tracking System (LUCATS). To perform detailed queries of these applications and find help interpreting LUCATS records, <a href="http://a030-lucats.nyc.gov/lucats/welcome.aspx" target="_blank">visit our Applicant Portal</a>.</p>
 
     <p>The Neighborhood Studies window links to background information on all of the ongoing and recently completed plans and studies that City Planning is conducting in each district. Some districts have no relevant current or recent studies, but <a href="http://www1.nyc.gov/site/planning/plans/proposals-studies.page" target="_blank">visit our website</a> to learn about plans and studies happening across the City, including archives going back decades.</p>
 
-    <h3>{{fa-icon "files-o"}} Resources</h3>
+    <h3 id="resources">{{fa-icon "files-o"}} Resources</h3>
 
     <div class="grid-x grid-padding-x">
       <div class="cell xlarge-7">

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -420,7 +420,7 @@
           <div class="cell large-4">
             <h4 class="subsection-header"><strong>Age of Buildings in Floodplain {{info-tooltip tip="Counts of buildings on lots that intersect with the 2015 PRIFM"}}</strong></h4>
             <div class="callout">
-              <p class="text-small">These counts are grouped based on {{#link-to 'about' (query-params section='built-environment')}}important dates{{/link-to}} in the history of NYC’s land-use and floodplain regulation.</p>
+              <p class="text-small">These counts are grouped based on {{#link-to 'about' (query-params section='floodplain')}}important dates{{/link-to}} in the history of NYC’s land-use and floodplain regulation.</p>
               {{building-age-chart borocd=model.borocd}}
             </div>
 

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -420,6 +420,7 @@
           <div class="cell large-4">
             <h4 class="subsection-header"><strong>Age of Buildings in Floodplain {{info-tooltip tip="Counts of buildings on lots that intersect with the 2015 PRIFM"}}</strong></h4>
             <div class="callout">
+              <p class="text-small">These counts are grouped based on {{#link-to 'about' (query-params section='built-environment')}}important dates{{/link-to}} in the history of NYC’s land-use and floodplain regulation.</p>
               {{building-age-chart borocd=model.borocd}}
             </div>
 

--- a/tests/unit/controllers/about-test.js
+++ b/tests/unit/controllers/about-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:about', 'Unit | Controller | about', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});


### PR DESCRIPTION
This PR addresses #346:  
- Updates Floodplain section as requested by Waterfront (text changes, big button for Hazard Mapper)
- Adds a Floodplain section to the about page (this placeholder content can be revised by the client)
- Enables linking to specific sections of the about page