### PR TITLE
Links to background on ACS indicators

### DIFF
--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -138,7 +138,7 @@
                             cd_stat=d.pct_hh_rent_burd
                             boro_stat=d.pct_hh_rent_burd_boro
                             city_stat=d.pct_hh_rent_burd_nyc}}
-            of households spend 35% or more of their income on&nbsp;rent
+            of households <a href="https://www.census.gov/topics/housing/about.html" target="_blank">spend 35% or more of their income on&nbsp;rent</a>
           {{/data.indicator}}
           {{#data.indicator class="indicator" name='Access to Parks'
                             column='pct_served_parks'
@@ -154,7 +154,7 @@
                             cd_stat=d.mean_commute
                             boro_stat=d.mean_commute_boro
                             city_stat=d.mean_commute_nyc}}
-            minutes
+            <a href="https://www.census.gov/topics/employment/commuting/about.html" target="_blank">minutes</a>
           {{/data.indicator}}
           {{#data.indicator class="indicator" name='Street Cleanliness'
                             column='pct_clean_strts'
@@ -182,7 +182,7 @@
                             cd_stat=d.pct_bach_deg
                             boro_stat=d.pct_bach_deg_boro
                             city_stat=d.pct_bach_deg_nyc}}
-            of residents 25 years or older have earned a bachelor's degree or&nbsp;higher
+            of residents 25 years or older have <a href="https://www.census.gov/topics/education/educational-attainment/about.html" target="_blank">earned a bachelor's degree or&nbsp;higher</a>
           {{/data.indicator}}
           {{#data.indicator class="indicator" name='Limited English Proficiency'
                             column='lep_rate'
@@ -192,7 +192,7 @@
                             cd_stat=d.lep_rate
                             boro_stat=d.lep_rate_boro
                             city_stat=d.lep_rate_nyc}}
-            of residents self-identify as having limited English&nbsp;proficiency
+            of residents self-identify as having <a href="https://www.census.gov/topics/population/language-use/about.html" target="_blank">limited English&nbsp;proficiency</a>
           {{/data.indicator}}
           {{#data.indicator class="indicator" name='Unemployment'
                             column='unemployment_cd'
@@ -202,7 +202,7 @@
                             cd_stat=d.unemployment_cd
                             boro_stat=d.unemployment_boro
                             city_stat=d.unemployment_nyc}}
-            of the civilian labor force is unemployed
+            of the <a href="https://www.census.gov/topics/employment/labor-force.html" target="_blank">civilian labor force is unemployed</a>
           {{/data.indicator}}
           {{#data.indicator class="indicator" name='Poverty'
                             column='poverty_rate'
@@ -212,7 +212,7 @@
                             cd_stat=d.poverty_rate
                             boro_stat=d.poverty_rate_boro
                             city_stat=d.poverty_rate_nyc}}
-            of residents have incomes below the poverty&nbsp;level
+            of residents have <a href="https://www.census.gov/topics/income-poverty/poverty.html" target="_blank">incomes below the poverty&nbsp;level</a>
           {{/data.indicator}}
         {{/key-indicators}}
 


### PR DESCRIPTION
Feedback from planners indicated that more information about Census data was necessary. I added links to the descriptions inside the ACS indicator boxes, which go to Census resources describing each subject in more detail.