### PR TITLE
Neighborhood disclaimer

### DIFF
--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -21,7 +21,7 @@
 
     <div class="district-content">
       <div class="neighborhoods-list">
-        {{model.neighborhoods}}
+        {{model.neighborhoods}} {{info-tooltip tip="Neighborhoods may be in multiple districts. Neighborhood names and boundaries are not officially designated."}}
       </div>
 
       <section class="page-section">

--- a/app/templates/profile.hbs
+++ b/app/templates/profile.hbs
@@ -602,7 +602,7 @@
             </div>
             <h4 class="subsection-header"><strong>Summary Community District Profile {{info-tooltip tip="Download a one-page PDF version of this community district profile designed for printing."}}</strong></h4>
             <div class="callout">
-              <a class="button small hollow expanded" target="_blank" href="https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/static-profiles/{{model.borocdAcronymLowerCase}}_profile.pdf">{{fa-icon "file-pdf-o"}} <strong>{{model.boro}} Community District {{model.cd}} Summary Profile</strong></a>
+              <a class="button small hollow expanded" target="_blank" href="https://docs.google.com/viewer?url=https://raw.githubusercontent.com/NYCPlanning/labs-cd-files/master/static-profiles/{{model.borocdAcronymLowerCase}}_profile.pdf">{{fa-icon "file-pdf-o"}} <strong>{{model.boro}} Community District {{model.cd}} Summary Profile</strong></a>
             </div>
           </div>
           {{log dataprofileColumns}}


### PR DESCRIPTION
Per #437 added tooltip disclaimer to neighborhood lists explaining that neighborhood names and boundaries are not officially designated.

Also restored Google preview to summary PDF profile download.